### PR TITLE
Release 1.2.0

### DIFF
--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -255,9 +255,7 @@ $(function() {
   <div id="fan-area">
     <?php
     require_once "$docroot/plugins/$plugin/include/FanBlockRender.php";
-    foreach ($all_cfg as $i => $cfg) {
-      echo render_fan_block($cfg, $i, $pwms, $disks);
-    }
+    echo render_fan_block($all_cfg[0], 0, $pwms, $disks);
     ?>
   </div>
     <div style="clear:both; margin-top:15px; text-align: left;">

--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -27,10 +27,6 @@ if (empty($all_cfg)) {
   $all_cfg[] = parse_ini_file($temp_file) + ['file' => basename($temp_file)];
 }
 
-echo "<pre>=== DEBUG: \$all_cfg ===\n";
-var_dump($all_cfg);
-echo "</pre>";
-
 function list_pwm() {
   $out = [];
   exec("find /sys/devices -type f -iname 'pwm[0-9]' -exec dirname \"{}\" + | uniq", $chips);
@@ -255,7 +251,9 @@ $(function() {
   <div id="fan-area">
     <?php
     require_once "$docroot/plugins/$plugin/include/FanBlockRender.php";
-    echo render_fan_block($all_cfg[0], 0, $pwms, $disks);
+    foreach ($all_cfg as $i => $cfg) {
+      echo render_fan_block($cfg, $i, $pwms, $disks);
+    }
     ?>
   </div>
     <div style="clear:both; margin-top:15px; text-align: left;">

--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -195,7 +195,8 @@ $(function() {
     $(this).dropdownchecklist({emptyText:'(None)', width:<?=$width?>, explicitClose:'...close'});
   });
 
-  $('form input, form select, form textarea').on('change keyup', function() {
+  // ✅ 使用事件委托绑定监听，支持后添加的 fan block
+  $('form').on('change keyup', 'input, select, textarea', function() {
     $('form').trigger('ui:changed');
   });
 

--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -31,7 +31,6 @@ if (empty($all_cfg)) {
 
 $pwms = list_pwm();
 $disks = list_valid_disks_by_id();
-echo "<pre>" . json_encode($disks, JSON_PRETTY_PRINT) . "</pre>";
 $width = 300;
 ?>
 
@@ -64,38 +63,23 @@ $(function() {
   }
 
   function updateAllFanStatus() {
-  console.log("✅ updateAllFanStatus triggered");
-
-  $.get('/plugins/fanctrlplus/include/FanctrlLogic.php', {op: 'status_all'}, function(statusMap) {
-    console.log("✅ statusMap:", statusMap);
-
-    $('.fan-block').each(function() {
-      const block = $(this);
-      const input = block.find('input[name^="custom["]');
-
-      if (!input.length) {
-        console.warn("⚠️ Skipping fan block with missing custom name input");
-        return;  // ❌ 防止报错
-      }
-
-      const name = input.val().trim();
-      const indicator = block.find('.fan-status');
-
-      console.log("→ block:", name, "indicator exists:", indicator.length > 0);
-
-      if (!indicator.length) return;
-
-      const matchedKey = Object.keys(statusMap).find(k => k.toLowerCase() === name.toLowerCase());
-      const status = matchedKey ? statusMap[matchedKey] : 'stopped';
-
-      console.log("→ matchedKey:", matchedKey, "status:", status);
-
-      indicator.text(status === 'running' ? '🟢' : '🔴');
+    $.get('/plugins/fanctrlplus/include/FanctrlLogic.php', {op: 'status_all'}, function(statusMap) {
+      $('.fan-block').each(function() {
+        const block = $(this);
+        const input = block.find('input[name^="custom["]');
+        if (!input.length) return;
+        const name = input.val().trim();
+        const indicator = block.find('.fan-status');
+        if (!indicator.length) return;
+        const matchedKey = Object.keys(statusMap).find(k => k.toLowerCase() === name.toLowerCase());
+        const status = matchedKey ? statusMap[matchedKey] : 'stopped';
+        indicator.text(status === 'running' ? '🟢' : '🔴');
+      });
+    }).fail(function(jqXHR, textStatus, errorThrown) {
+      console.error("❌ Failed to load status_all:", textStatus, errorThrown);
     });
-  }).fail(function(jqXHR, textStatus, errorThrown) {
-    console.error("❌ Failed to load status_all:", textStatus, errorThrown);
-  });
-}
+  }
+
   updateStatusLightAndButton();
   updateAllFanStatus();
 
@@ -110,15 +94,11 @@ $(function() {
     const action = btn.text().includes('Stop') ? 'stop' : 'start';
 
     $.get('/plugins/fanctrlplus/include/FanctrlLogic.php', {op: action}, function() {
-      // 每 500ms 检查一次，最多等 10 次（5 秒）
-      let tries = 0;
-      const maxTries = 10;
-
+      let tries = 0, maxTries = 10;
       const check = () => {
         $.get('/plugins/fanctrlplus/include/FanctrlLogic.php', {op: 'status'}, function(data) {
           const isRunning = data.status === 'running';
           const wantRunning = action === 'start';
-
           if (isRunning === wantRunning || tries >= maxTries) {
             updateStatusLightAndButton();
             updateAllFanStatus();
@@ -129,13 +109,12 @@ $(function() {
           }
         });
       };
-
-    check();
-  }).fail(function(jqXHR, textStatus, errorThrown) {
-    console.error("❌ Toggle daemon failed:", textStatus, errorThrown);
-    btn.prop('disabled', false);
-  });
-};
+      check();
+    }).fail(function(jqXHR, textStatus, errorThrown) {
+      console.error("❌ Toggle daemon failed:", textStatus, errorThrown);
+      btn.prop('disabled', false);
+    });
+  };
 
   window.pauseFan = function(pwm, btn) {
     $(btn).prop('disabled', true).text("Pausing...");
@@ -157,27 +136,19 @@ $(function() {
     if (!confirm("Are you sure you want to delete this fan configuration?")) return;
     const block = $(btn).closest('.fan-block');
     const file = block.find('input.cfg-file').val();
-
     $.post('/plugins/fanctrlplus/include/FanctrlLogic.php', {op:'delete', file: file})
       .done(function(result) {
-        console.log("✅ Fan deleted:", result);
-        block.remove();                  // ✅ 先从页面移除
-        setTimeout(() => {
-          updateAllFanStatus();         // ✅ 然后刷新 status 灯
-        }, 500);
+        block.remove();
+        setTimeout(() => updateAllFanStatus(), 500);
       })
       .fail(function(jqXHR, textStatus, errorThrown) {
-        console.error("❌ Delete fan failed:", textStatus, errorThrown);
         alert("Failed to delete fan.");
       });
   };
 
   window.addFan = function() {
-    console.log("🟡 Add Fan clicked");
     const index = $('.fan-block').length;
-  
     $.post('/plugins/fanctrlplus/include/FanctrlLogic.php', {op:'newtemp', index: index}, function(html) {
-      console.log("🟢 Fan HTML received");
       $('#fan-area').append(html);
       updateAllFanStatus();
       $('.disk-select').last().dropdownchecklist({
@@ -185,9 +156,7 @@ $(function() {
         width: <?=$width?>,
         explicitClose:'...close'
       });
-    }, 'html')  // ✅ 指定 HTML 返回类型，避免 JSON.parse 报错
-    .fail(function(jqXHR, textStatus, errorThrown) {
-      console.error("🔴 Add fan failed:", textStatus, errorThrown);
+    }, 'html').fail(function(jqXHR, textStatus, errorThrown) {
       alert("Failed to add fan.");
     });
   };
@@ -196,39 +165,16 @@ $(function() {
     $(this).dropdownchecklist({emptyText:'(None)', width:<?=$width?>, explicitClose:'...close'});
   });
 
-  // ✅ 使用事件委托绑定监听，支持后添加的 fan block
   $('form').on('change keyup', 'input, select, textarea', function() {
     $('form').trigger('ui:changed');
   });
 
-    // 👉 用户修改任何字段后激活 Apply 按钮
-  $('form input, form select, form textarea').on('change keyup', function() {
-    $('form').trigger('ui:changed');
-  });
-
-  // 👉 触发 ui:changed 时启用按钮
   $('form').on('ui:changed', function() {
     $('input[name="#apply"]').prop('disabled', false);
   });
 
-  // 👉 页面初始时禁用按钮
   $(document).ready(function() {
     $('input[name="#apply"]').prop('disabled', true);
-  });
-
-  // 👉 用户点击 Apply 后再次禁用按钮（可选）
-  $('form').on('submit', function() {
-    $('input[name="#apply"]').prop('disabled', true);
-    let valid = true;
-    $('input[name^="custom["]').each(function() {
-      if ($(this).val().trim() === '') {
-        alert("Custom Name cannot be empty!");
-        $(this).focus();
-        valid = false;
-        return false;
-      }
-    });
-    return valid;
   });
 
   $('form').on('submit', function() {
@@ -256,9 +202,9 @@ $(function() {
     }
     ?>
   </div>
-    <div style="clear:both; margin-top:15px; text-align: left;">
-      <button type="button" onclick="addFan()" title="Add a new fan controller block">➕ Add Fan</button>
-      <input type="submit" name="#apply" value="Apply All" title="Save all fan configurations">
-      <button type="button" id="toggle-daemon" onclick="toggleDaemon()" disabled>Loading...</button>
-    </div>
+  <div style="clear:both; margin-top:15px; text-align: left;">
+    <button type="button" onclick="addFan()" title="Add a new fan controller block">➕ Add Fan</button>
+    <input type="submit" name="#apply" value="Apply All" title="Save all fan configurations">
+    <button type="button" id="toggle-daemon" onclick="toggleDaemon()" disabled>Loading...</button>
+  </div>
 </form>

--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -63,30 +63,38 @@ $(function() {
   }
 
   function updateAllFanStatus() {
-    console.log("✅ updateAllFanStatus triggered");
-    $.get('/plugins/fanctrlplus/include/FanctrlLogic.php', {op: 'status_all'}, function(statusMap) {
-      console.log("✅ statusMap:", statusMap);
+  console.log("✅ updateAllFanStatus triggered");
 
-      $('.fan-block').each(function() {
-        const block = $(this);
-        const name = block.find('input[name^="custom["]').val().trim();
-        const indicator = block.find('.fan-status');
+  $.get('/plugins/fanctrlplus/include/FanctrlLogic.php', {op: 'status_all'}, function(statusMap) {
+    console.log("✅ statusMap:", statusMap);
 
-        console.log("→ block:", name, "indicator exists:", indicator.length > 0);
+    $('.fan-block').each(function() {
+      const block = $(this);
+      const input = block.find('input[name^="custom["]');
 
-        if (!indicator.length) return;
+      if (!input.length) {
+        console.warn("⚠️ Skipping fan block with missing custom name input");
+        return;  // ❌ 防止报错
+      }
 
-        const matchedKey = Object.keys(statusMap).find(k => k.toLowerCase() === name.toLowerCase());
-        const status = matchedKey ? statusMap[matchedKey] : 'stopped';
+      const name = input.val().trim();
+      const indicator = block.find('.fan-status');
 
-        console.log("→ matchedKey:", matchedKey, "status:", status);
+      console.log("→ block:", name, "indicator exists:", indicator.length > 0);
 
-        indicator.text(status === 'running' ? '🟢' : '🔴');
-      });
-    }).fail(function(jqXHR, textStatus, errorThrown) {
-      console.error("❌ Failed to load status_all:", textStatus, errorThrown);
+      if (!indicator.length) return;
+
+      const matchedKey = Object.keys(statusMap).find(k => k.toLowerCase() === name.toLowerCase());
+      const status = matchedKey ? statusMap[matchedKey] : 'stopped';
+
+      console.log("→ matchedKey:", matchedKey, "status:", status);
+
+      indicator.text(status === 'running' ? '🟢' : '🔴');
     });
-  }
+  }).fail(function(jqXHR, textStatus, errorThrown) {
+    console.error("❌ Failed to load status_all:", textStatus, errorThrown);
+  });
+}
   updateStatusLightAndButton();
   updateAllFanStatus();
 

--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -7,6 +7,8 @@ Icon="fanctrlplus.png"
 $plugin = "fanctrlplus";
 $cfg_dir = "/boot/config/plugins/$plugin";
 
+require_once "$docroot/plugins/$plugin/include/Common.php";
+
 // 初始化配置
 if (!is_dir($cfg_dir)) {
   mkdir($cfg_dir, 0777, true);
@@ -25,48 +27,6 @@ if (empty($all_cfg)) {
     file_put_contents($temp_file, "custom=\"\"\nservice=\"1\"\ncontroller=\"\"\npwm=\"100\"\nlow=\"40\"\nhigh=\"60\"\ninterval=\"2\"\ndisks=\"\"");
   }
   $all_cfg[] = parse_ini_file($temp_file) + ['file' => basename($temp_file)];
-}
-
-function list_pwm() {
-  $out = [];
-  exec("find /sys/devices -type f -iname 'pwm[0-9]' -exec dirname \"{}\" + | uniq", $chips);
-  foreach ($chips as $chip) {
-    $name = is_file("$chip/name") ? file_get_contents("$chip/name") : '';
-    foreach (glob("$chip/pwm[0-9]") as $pwm) {
-      $out[] = ['chip'=>$name, 'name'=>basename($pwm), 'sensor'=>$pwm];
-    }
-  }
-  return $out;
-}
-
-function list_valid_disks_by_id() {
-  $seen = [];
-  $result = [];
-
-  // 获取 Unraid 启动盘对应的设备，例如 /dev/sda1 或 /dev/sdb1
-  $boot_mount = realpath("/boot");
-  $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
-  $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);  // 去除分区号，例如 /dev/sda1 → /dev/sda
-
-  foreach (glob("/dev/disk/by-id/*") as $dev) {
-    if (!is_link($dev) || strpos($dev, "part") !== false) continue;
-
-    $real = realpath($dev);
-    if ($real === false) continue;
-
-    // 只保留 sdX 或 nvme 设备
-    if (strpos($real, "/dev/sd") === false && strpos($real, "/dev/nvme") === false) continue;
-
-    // 跳过 Unraid 启动的设备（例如 /dev/sda）
-    if (strpos($real, $boot_dev_base) === 0) continue;
-
-    if (in_array($real, $seen)) continue;
-
-    $seen[] = $real;
-    $result[] = ['id' => basename($dev), 'dev' => $real];
-  }
-
-  return $result;
 }
 
 $pwms = list_pwm();

--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -31,6 +31,7 @@ if (empty($all_cfg)) {
 
 $pwms = list_pwm();
 $disks = list_valid_disks_by_id();
+echo "<pre>" . json_encode($disks, JSON_PRETTY_PRINT) . "</pre>";
 $width = 300;
 ?>
 

--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -199,6 +199,36 @@ $(function() {
     $('form').trigger('ui:changed');
   });
 
+    // 👉 用户修改任何字段后激活 Apply 按钮
+  $('form input, form select, form textarea').on('change keyup', function() {
+    $('form').trigger('ui:changed');
+  });
+
+  // 👉 触发 ui:changed 时启用按钮
+  $('form').on('ui:changed', function() {
+    $('input[name="#apply"]').prop('disabled', false);
+  });
+
+  // 👉 页面初始时禁用按钮
+  $(document).ready(function() {
+    $('input[name="#apply"]').prop('disabled', true);
+  });
+
+  // 👉 用户点击 Apply 后再次禁用按钮（可选）
+  $('form').on('submit', function() {
+    $('input[name="#apply"]').prop('disabled', true);
+    let valid = true;
+    $('input[name^="custom["]').each(function() {
+      if ($(this).val().trim() === '') {
+        alert("Custom Name cannot be empty!");
+        $(this).focus();
+        valid = false;
+        return false;
+      }
+    });
+    return valid;
+  });
+
   $('form').on('submit', function() {
     let valid = true;
     $('input[name^="custom["]').each(function() {

--- a/include/Common.php
+++ b/include/Common.php
@@ -51,11 +51,11 @@ function list_valid_disks_by_id() {
     $md_base = exec("findmnt -n -o SOURCE --target $real 2>/dev/null");
     $md_base = preg_replace('#p?[0-9]+$#', '', $md_base);
     if (isset($md_to_disk[$md_base])) {
-      $label .= " → " . $md_to_disk[$md_base];  // 显示 disk1、disk2 标签
+      $label .= isset($sd_to_disk[$real]) ? " → " . $sd_to_disk[$real] : ' [NO MATCH]';
+      error_log("[fanctrlplus] match $real → " . $sd_to_disk[$real]);
     }
 
     $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
-    error_log("[fanctrlplus] match $real → "
   }
 
   usort($result, fn($a, $b) => strnatcasecmp($a['id'], $b['id']));

--- a/include/Common.php
+++ b/include/Common.php
@@ -21,14 +21,47 @@ function list_valid_disks_by_id() {
   $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
   $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
 
-  // 用 /dev/disk/by-label/diskX 反向匹配实际设备路径
-  $sd_to_disk = [];
-  foreach (glob("/dev/disk/by-label/disk*") as $label_path) {
-    $real = realpath($label_path);
-    if ($real && strpos($real, '/dev/') === 0) {
-      $sd_to_disk[$real] = basename($label_path);  // 例如 /dev/sdg → disk1
+  // 建立 diskX 映射（从 /mnt/diskX → /dev/sdX）
+  $dev_to_disk = [];
+  foreach (glob("/mnt/disk*") as $mnt) {
+    $real = realpath($mnt);  // 会返回 /dev/mdX 或 /dev/sdX1
+    if ($real && preg_match('#/dev/(sd[a-z]+)[0-9]*$#', $real, $m)) {
+      $dev_base = "/dev/" . $m[1];  // 提取 /dev/sdX
+      $dev_to_disk[$dev_base] = basename($mnt);  // /dev/sdX → disk1
     }
   }
+
+  foreach (glob("/dev/disk/by-id/*") as $dev) {
+    if (!is_link($dev) || strpos($dev, "part") !== false) continue;
+    if (strpos(basename($dev), 'usb-') === 0) continue;
+
+    $real = realpath($dev);
+    if ($real === false) continue;
+    if (strpos($real, "/dev/sd") === false && strpos($real, "/dev/nvme") === false) continue;
+    if (strpos($real, $boot_dev_base) === 0) continue;
+    if (in_array($real, $seen)) continue;
+
+    $seen[] = $real;
+    $id = basename($dev);
+    $label = $id;
+
+    // 追加 diskX 标签（通过 dev_base 匹配）
+    if (preg_match('#/dev/(sd[a-z]+)#', $real, $m)) {
+      $dev_base = "/dev/" . $m[1];
+      if (isset($dev_to_disk[$dev_base])) {
+        $label .= " → " . $dev_to_disk[$dev_base];
+      }
+    }
+
+    $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
+  }
+
+  usort($result, function($a, $b) {
+    return strnatcasecmp($a['id'], $b['id']);
+  });
+
+  return $result;
+}
 
   foreach (glob("/dev/disk/by-id/*") as $dev) {
     if (!is_link($dev) || strpos($dev, "part") !== false) continue;

--- a/include/Common.php
+++ b/include/Common.php
@@ -65,7 +65,70 @@ function list_valid_disks_by_id() {
         $label .= " → " . $dev_to_disk[$base];
         error_log("[fanctrlplus] matched $base → {$dev_to_disk[$base]} for id=$id");
       } else {
+        error_log("[fanctrlplus] no match for $base (id=$id)");function list_valid_disks_by_id() {
+  $seen = [];
+  $result = [];
+
+  // 建立 /dev/sdX 或 /dev/nvmeXn1 → diskX 的反向映射
+  $dev_to_disk = [];
+
+  // 使用 lsblk 分析 /mnt/diskX 实际来源设备
+  foreach (glob("/mnt/disk*") as $mnt) {
+    $mountpoint = escapeshellarg($mnt);
+    $output = shell_exec("lsblk -no NAME,MOUNTPOINT /dev/md* 2>/dev/null");
+    // 手动逐行找出 mdXp1 -> diskX
+    exec("findmnt -n -o SOURCE --target $mountpoint", $out);
+    if (!empty($out[0])) {
+      $src = trim($out[0]); // /dev/mdXp1
+      $parents = shell_exec("lsblk -no PKNAME $src 2>/dev/null");  // 可能返回 sdd
+      $parent = trim($parents);
+      if ($parent && strpos($parent, 'loop') === false) {
+        $base = "/dev/" . $parent;
+        $dev_to_disk[$base] = basename($mnt); // disk1, disk2...
+        error_log("[fanctrlplus] map $base ← " . basename($mnt));
+      }
+    }
+  }
+
+  $boot_mount = realpath("/boot");
+  $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
+  $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
+
+  foreach (glob("/dev/disk/by-id/*") as $dev) {
+    if (!is_link($dev) || strpos($dev, "part") !== false) continue;
+    if (strpos(basename($dev), 'usb-') === 0) continue;
+
+    $real = realpath($dev);
+    if ($real === false) continue;
+    if (strpos($real, "/dev/sd") === false && strpos($real, "/dev/nvme") === false) continue;
+    if (strpos($real, $boot_dev_base) === 0) continue;
+    if (in_array($real, $seen)) continue;
+
+    $seen[] = $real;
+    $id = basename($dev);
+    $label = $id;
+
+    // 从 /dev/sdX1 或 /dev/nvmeXn1p1 → /dev/sdX
+    if (preg_match('#/dev/([a-z0-9]+)[p]?[0-9]*$#', $real, $m)) {
+      $base = "/dev/" . $m[1];
+      if (isset($dev_to_disk[$base])) {
+        $label .= " → " . $dev_to_disk[$base];
+        error_log("[fanctrlplus] matched $base → {$dev_to_disk[$base]} for id=$id");
+      } else {
         error_log("[fanctrlplus] no match for $base (id=$id)");
+      }
+    } else {
+      error_log("[fanctrlplus] no match regex for real=$real");
+    }
+
+    error_log("[fanctrlplus] disk id=$id real=$real label=$label");
+    $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
+  }
+
+  usort($result, fn($a, $b) => strnatcasecmp($a['id'], $b['id']));
+  error_log("[fanctrlplus] final disk list count: " . count($result));
+  return $result;
+}
       }
     } else {
       error_log("[fanctrlplus] no match regex for real=$real");

--- a/include/Common.php
+++ b/include/Common.php
@@ -10,7 +10,7 @@ function list_pwm() {
     }
   }
 
-  // 修正：按 name 字段排序（如 pwm1, pwm2...）
+  // 按 pwm 名称排序（例如 pwm1, pwm2...）
   usort($out, function ($a, $b) {
     return strcmp($a['name'], $b['name']);
   });
@@ -26,13 +26,13 @@ function list_valid_disks_by_id() {
   $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
   $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
 
-  // 改用 findmnt 获取 /mnt/diskX 实际设备
+  // 映射 /dev/sdX → diskX（只针对 array 成员）
   $sd_to_disk = [];
   foreach (glob("/mnt/disk*") as $disk_path) {
     $dev = exec("findmnt -n -o SOURCE --target " . escapeshellarg($disk_path));
-    $dev_base = preg_replace('#[0-9]+$#', '', $dev);  // 去掉 /dev/sdX1 的分区号
+    $dev_base = preg_replace('#[0-9]+$#', '', $dev);
     if ($dev_base && strpos($dev_base, '/dev/') === 0) {
-      $sd_to_disk[$dev_base] = basename($disk_path);  // e.g. /dev/sdd → disk1
+      $sd_to_disk[$dev_base] = basename($disk_path);  // /dev/sdd → disk1
     }
   }
 
@@ -50,20 +50,13 @@ function list_valid_disks_by_id() {
     $id = basename($dev);
     $label = $id;
 
-    // 匹配真实设备路径是否存在于 diskX 映射表中
+    // 若设备是 diskX，则追加 disk 名标签
     if (isset($sd_to_disk[$real])) {
-      $label .= " → " . $sd_to_disk[$real];  // ✅ 追加 disk1、disk2 标签
+      $label .= " → " . $sd_to_disk[$real];
     }
 
     $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
   }
-
-  usort($result, function($a, $b) {
-    return strnatcasecmp($a['id'], $b['id']);
-  });
-
-  return $result;
-}
 
   usort($result, function($a, $b) {
     return strnatcasecmp($a['id'], $b['id']);

--- a/include/Common.php
+++ b/include/Common.php
@@ -18,22 +18,21 @@ function list_valid_disks_by_id() {
   $seen = [];
   $groups = [];
 
-  // 获取 Array 中 /dev/sdX → DiskX/Parity 映射
+  // 1. 获取 Array 映射
   $dev_to_diskx = [];
-  $lines = shell_exec("/usr/local/sbin/mdcmd status | grep rdevName");
-  foreach (explode("\n", $lines) as $line) {
+  foreach (explode("\n", shell_exec("/usr/local/sbin/mdcmd status | grep rdevName")) as $line) {
     if (preg_match('/rdevName\.(\d+)=(\w+)/', $line, $m)) {
-      $slot = intval($m[1]);
-      $dev  = "/dev/" . trim($m[2]);
-      $dev_to_diskx[$dev] = match (true) {
-        $slot === 0  => 'Parity',
-        $slot === 29 => 'Parity 2',
-        default      => 'Disk ' . $slot
+      $slot = (int)$m[1];
+      $dev  = "/dev/" . $m[2];
+      $dev_to_diskx[$dev] = match ($slot) {
+        0 => 'Parity',
+        29 => 'Parity 2',
+        default => "Disk $slot"
       };
     }
   }
 
-  // 查找 Pool → 挂载路径
+  // 2. 获取所有 Pool 挂载路径
   $pools = [];
   foreach (glob("/mnt/*") as $path) {
     $base = basename($path);
@@ -43,25 +42,27 @@ function list_valid_disks_by_id() {
     $pools[$base] = $path;
   }
 
-  // 获取 /dev/xxxp1 → Pool 名称映射
+  // 3. 获取 dev → Pool 名的映射
   $dev_to_pool = [];
   $blk = json_decode(shell_exec("lsblk -pJ -o NAME,KNAME,MOUNTPOINT 2>/dev/null"), true);
   foreach (($blk['blockdevices'] ?? []) as $dev) {
-    foreach (($dev['children'] ?? []) as $child) {
-      $kname = $child['kname'] ?? '';
-      $mount = $child['mountpoint'] ?? '';
+    $name = $dev['name'] ?? '';
+    foreach ($dev['children'] ?? [] as $child) {
+      $mp = $child['mountpoint'] ?? '';
+      if (!$mp) continue;
       foreach ($pools as $pool => $mnt) {
-        if ($mount && strpos($mount, $mnt) === 0) {
-          $dev_to_pool["/dev/$kname"] = ucfirst($pool);
+        if (strpos($mp, $mnt) === 0) {
+          $dev_to_pool[$name] = ucfirst($pool);  // ✅ 记录 parent 设备名
         }
       }
     }
   }
 
-  // boot device
+  // 4. 忽略 boot 所在设备
   $boot_dev = exec("findmnt -n -o SOURCE --target /boot 2>/dev/null");
   $boot_base = preg_replace('#[0-9]+$#', '', $boot_dev);
 
+  // 5. 遍历 /dev/disk/by-id 并生成列表
   foreach (glob("/dev/disk/by-id/*") as $dev) {
     if (!is_link($dev) || strpos($dev, 'part') !== false) continue;
     if (strpos(basename($dev), 'usb-') === 0) continue;
@@ -75,24 +76,19 @@ function list_valid_disks_by_id() {
     $label = preg_replace('/^(nvme|ata)-/', '', $id);
     $title = "$id\n$real";
 
-    $group = "Others";
+    $base = preg_replace('#[p]?[0-9]+$#', '', $real);  // ✅ 获取父设备
 
-    if (preg_match('#/dev/([a-z0-9]+)[p]?[0-9]*$#', $real, $m)) {
-      $base = "/dev/" . $m[1];
-      $basename = basename($real);
-
-      if (isset($dev_to_diskx[$base])) {
-        $label = $dev_to_diskx[$base] . " - " . $label;
-        $group = "Array";
-      } else {
-        $base_real = preg_replace('#[p]?[0-9]+$#', '', $real);
-        if (isset($dev_to_pool[$base_real])) {
-          $label .= " (" . basename($base_real) . ")";
-          $group = $dev_to_pool[$base_real];
-        } else {
-          $label .= " (" . basename($real) . ")";
-        }
-      }
+    if (isset($dev_to_diskx[$base])) {
+      $label = $dev_to_diskx[$base] . " - " . $label;
+      $group = "Array";
+    } elseif (isset($dev_to_pool[$base])) {
+      $nvme = basename($base);
+      $label .= " ($nvme)";
+      $group = $dev_to_pool[$base];
+    } else {
+      $nvme = basename($real);
+      $label .= " ($nvme)";
+      $group = "Others";
     }
 
     $groups[$group][] = [
@@ -103,25 +99,25 @@ function list_valid_disks_by_id() {
     ];
   }
 
-  // 分组排序：Array → Pool（字母序）→ Others
+  // 6. 排序 group：Array → Pools → Others
   uksort($groups, function($a, $b) {
-    if ($a === "Array") return -1;
-    if ($b === "Array") return 1;
-    if ($a === "Others") return 1;
-    if ($b === "Others") return -1;
+    if ($a === 'Array') return -1;
+    if ($b === 'Array') return 1;
+    if ($a === 'Others') return 1;
+    if ($b === 'Others') return -1;
     return strnatcasecmp($a, $b);
   });
 
-  // 排序 Array 内部 Disk 顺序
-  if (isset($groups["Array"])) {
-    usort($groups["Array"], function($a, $b) {
+  // 排序 Array 内部 DiskX
+  if (isset($groups['Array'])) {
+    usort($groups['Array'], function($a, $b) {
       preg_match('/Disk (\d+)/', $a['label'], $ma);
       preg_match('/Disk (\d+)/', $b['label'], $mb);
       return ($ma[1] ?? 99) <=> ($mb[1] ?? 99);
     });
   }
 
-  // 其他组按 label 排序
+  // 排序其他组按 label
   foreach ($groups as $key => &$entries) {
     if ($key !== 'Array') {
       usort($entries, fn($a, $b) => strnatcasecmp($a['label'], $b['label']));

--- a/include/Common.php
+++ b/include/Common.php
@@ -6,9 +6,15 @@ function list_pwm() {
   foreach ($chips as $chip) {
     $name = is_file("$chip/name") ? file_get_contents("$chip/name") : '';
     foreach (glob("$chip/pwm[0-9]") as $pwm) {
-      $out[] = ['chip'=>$name, 'name'=>basename($pwm), 'sensor'=>$pwm];
+      $out[] = ['chip' => $name, 'name' => basename($pwm), 'sensor' => $pwm];
     }
   }
+
+  // 修正：按 name 字段排序（如 pwm1, pwm2...）
+  usort($out, function ($a, $b) {
+    return strcmp($a['name'], $b['name']);
+  });
+
   return $out;
 }
 
@@ -22,6 +28,7 @@ function list_valid_disks_by_id() {
 
   foreach (glob("/dev/disk/by-id/*") as $dev) {
     if (!is_link($dev) || strpos($dev, "part") !== false) continue;
+    if (strpos(basename($dev), 'usb-') === 0) continue; // 排除 USB 启动盘
     $real = realpath($dev);
     if ($real === false) continue;
     if (strpos($real, "/dev/sd") === false && strpos($real, "/dev/nvme") === false) continue;

--- a/include/Common.php
+++ b/include/Common.php
@@ -10,11 +10,7 @@ function list_pwm() {
     }
   }
 
-  // 按 pwm 名称排序（例如 pwm1, pwm2...）
-  usort($out, function ($a, $b) {
-    return strcmp($a['name'], $b['name']);
-  });
-
+  usort($out, fn($a, $b) => strcmp($a['name'], $b['name']));
   return $out;
 }
 
@@ -26,16 +22,17 @@ function list_valid_disks_by_id() {
   $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
   $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
 
-  // 映射 /dev/sdX → diskX（只针对 array 成员）
-  $sd_to_disk = [];
+  // 获取 /mnt/diskX → /dev/mdX 映射
+  $md_to_disk = [];
   foreach (glob("/mnt/disk*") as $disk_path) {
-    $dev = exec("findmnt -n -o SOURCE --target " . escapeshellarg($disk_path));
-    $dev_base = preg_replace('#p?[0-9]+$#', '', $dev);
-    if ($dev_base && strpos($dev_base, '/dev/') === 0) {
-      $sd_to_disk[$dev_base] = basename($disk_path);  // /dev/sdd → disk1
+    $src = exec("findmnt -n -o SOURCE --target " . escapeshellarg($disk_path));
+    $md_base = preg_replace('#p?[0-9]+$#', '', $src);
+    if (strpos($md_base, "/dev/md") === 0) {
+      $md_to_disk[$md_base] = basename($disk_path);  // /dev/md1 → disk1
     }
   }
 
+  // 获取 /dev/disk/by-id/* → /dev/mdX 的反向映射
   foreach (glob("/dev/disk/by-id/*") as $dev) {
     if (!is_link($dev) || strpos($dev, "part") !== false) continue;
     if (strpos(basename($dev), 'usb-') === 0) continue;
@@ -50,17 +47,16 @@ function list_valid_disks_by_id() {
     $id = basename($dev);
     $label = $id;
 
-    // 若设备是 diskX，则追加 disk 名标签
-    if (isset($sd_to_disk[$real])) {
-      $label .= " → " . $sd_to_disk[$real];
+    // 匹配：该 by-id 所属物理盘是否属于 array 的 /dev/mdX
+    $md_base = exec("findmnt -n -o SOURCE --target $real 2>/dev/null");
+    $md_base = preg_replace('#p?[0-9]+$#', '', $md_base);
+    if (isset($md_to_disk[$md_base])) {
+      $label .= " → " . $md_to_disk[$md_base];  // 显示 disk1、disk2 标签
     }
 
     $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
   }
 
-  usort($result, function($a, $b) {
-    return strnatcasecmp($a['id'], $b['id']);
-  });
-
+  usort($result, fn($a, $b) => strnatcasecmp($a['id'], $b['id']));
   return $result;
 }

--- a/include/Common.php
+++ b/include/Common.php
@@ -13,7 +13,6 @@ function list_pwm() {
   usort($out, fn($a, $b) => strcmp($a['name'], $b['name']));
   return $out;
 }
-
 function list_valid_disks_by_id() {
   $seen = [];
   $result = [];
@@ -22,17 +21,15 @@ function list_valid_disks_by_id() {
   $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
   $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
 
-  // 获取 /mnt/diskX → /dev/mdX 映射
-  $md_to_disk = [];
-  foreach (glob("/mnt/disk*") as $disk_path) {
-    $src = exec("findmnt -n -o SOURCE --target " . escapeshellarg($disk_path));
-    $md_base = preg_replace('#p?[0-9]+$#', '', $src);
-    if (strpos($md_base, "/dev/md") === 0) {
-      $md_to_disk[$md_base] = basename($disk_path);  // /dev/md1 → disk1
+  // 用 /dev/disk/by-label/diskX 反向匹配实际设备路径
+  $sd_to_disk = [];
+  foreach (glob("/dev/disk/by-label/disk*") as $label_path) {
+    $real = realpath($label_path);
+    if ($real && strpos($real, '/dev/') === 0) {
+      $sd_to_disk[$real] = basename($label_path);  // 例如 /dev/sdg → disk1
     }
   }
 
-  // 获取 /dev/disk/by-id/* → /dev/mdX 的反向映射
   foreach (glob("/dev/disk/by-id/*") as $dev) {
     if (!is_link($dev) || strpos($dev, "part") !== false) continue;
     if (strpos(basename($dev), 'usb-') === 0) continue;
@@ -47,17 +44,16 @@ function list_valid_disks_by_id() {
     $id = basename($dev);
     $label = $id;
 
-    // 匹配：该 by-id 所属物理盘是否属于 array 的 /dev/mdX
-    $md_base = exec("findmnt -n -o SOURCE --target $real 2>/dev/null");
-    $md_base = preg_replace('#p?[0-9]+$#', '', $md_base);
-    if (isset($md_to_disk[$md_base])) {
-      $label .= isset($sd_to_disk[$real]) ? " → " . $sd_to_disk[$real] : ' [NO MATCH]';
-      error_log("[fanctrlplus] match $real → " . $sd_to_disk[$real]);
+    if (isset($sd_to_disk[$real])) {
+      $label .= " → " . $sd_to_disk[$real];  // ✅ 显示 disk1、disk2
     }
 
     $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
   }
 
-  usort($result, fn($a, $b) => strnatcasecmp($a['id'], $b['id']));
+  usort($result, function($a, $b) {
+    return strnatcasecmp($a['id'], $b['id']);
+  });
+
   return $result;
 }

--- a/include/Common.php
+++ b/include/Common.php
@@ -15,6 +15,23 @@ function list_pwm() {
   return $out;
 }
 
+<?php
+
+function list_pwm() {
+  $out = [];
+  exec("find /sys/devices -type f -iname 'pwm[0-9]' -exec dirname \"{}\" + | uniq", $chips);
+  foreach ($chips as $chip) {
+    $name = is_file("$chip/name") ? file_get_contents("$chip/name") : '';
+    foreach (glob("$chip/pwm[0-9]") as $pwm) {
+      $out[] = ['chip' => $name, 'name' => basename($pwm), 'sensor' => $pwm];
+    }
+  }
+
+  // 按 pwm 名称排序（例如 pwm1, pwm2...）
+  usort($out, fn($a, $b) => strcmp($a['name'], $b['name']));
+  return $out;
+}
+
 function list_valid_disks_by_id() {
   $seen = [];
   $result = [];

--- a/include/Common.php
+++ b/include/Common.php
@@ -16,6 +16,8 @@ function list_pwm() {
   });
 
   return $out;
+}
+
 function list_valid_disks_by_id() {
   $seen = [];
   $result = [];
@@ -24,7 +26,7 @@ function list_valid_disks_by_id() {
   $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
   $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
 
-  // 建立 /dev/sdX → diskX 的映射（只包含 array 中的 disk1、disk2、...）
+  // 建立 /dev/sdX → diskX 的映射
   $sd_to_disk = [];
   foreach (glob("/mnt/disk*") as $disk_path) {
     $real = realpath($disk_path);
@@ -46,17 +48,16 @@ function list_valid_disks_by_id() {
     $seen[] = $real;
 
     $id = basename($dev);
+    $dev_short = basename($real);
     $label = $id;
 
-    // 若该设备在 /mnt/diskX 中被挂载，追加 diskX 标签
     if (isset($sd_to_disk[$real])) {
       $label .= " → " . $sd_to_disk[$real];
     }
 
-    $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
+    $result[] = ['id' => $id, 'dev' => $dev_short, 'label' => $label];
   }
 
-  // 排序（根据 id 自然排序）
   usort($result, function($a, $b) {
     return strnatcasecmp($a['id'], $b['id']);
   });

--- a/include/Common.php
+++ b/include/Common.php
@@ -30,7 +30,7 @@ function list_valid_disks_by_id() {
   $sd_to_disk = [];
   foreach (glob("/mnt/disk*") as $disk_path) {
     $dev = exec("findmnt -n -o SOURCE --target " . escapeshellarg($disk_path));
-    $dev_base = preg_replace('#[0-9]+$#', '', $dev);
+    $dev_base = preg_replace('#p?[0-9]+$#', '', $dev);
     if ($dev_base && strpos($dev_base, '/dev/') === 0) {
       $sd_to_disk[$dev_base] = basename($disk_path);  // /dev/sdd → disk1
     }

--- a/include/Common.php
+++ b/include/Common.php
@@ -16,98 +16,109 @@ function list_pwm() {
 
 function list_valid_disks_by_id() {
   $seen = [];
+  $result = [];
   $groups = [];
 
-  // 获取 Array 设备映射（/dev/sdX -> Parity/diskX）
-  $dev_to_label = [];
-  $array_order = [];
+  // 获取 dev → DiskX/Parity 映射
+  $dev_to_diskx = [];
   $lines = shell_exec("/usr/local/sbin/mdcmd status | grep rdevName");
   foreach (explode("\n", $lines) as $line) {
     if (preg_match('/rdevName\.(\d+)=(\w+)/', $line, $m)) {
       $slot = intval($m[1]);
       $dev  = "/dev/" . trim($m[2]);
-      if ($slot == 0) {
-        $label = "Parity";
-      } elseif ($slot == 29) {
-        $label = "Parity 2";
-      } else {
-        $label = "Disk " . $slot;
-      }
-      $dev_to_label[$dev] = $label;
-      $array_order[$label] = $slot;  // 用于排序
+      $dev_to_diskx[$dev] = match (true) {
+        $slot === 0  => 'Parity',
+        $slot === 29 => 'Parity 2',
+        default      => 'Disk ' . $slot
+      };
     }
   }
 
-  // 获取每个设备 -> pool 名的映射
-  $pool_map = [];
-  foreach (glob("/etc/libvirt/lxc/*/config") as $file) {
-    $pool = basename(dirname($file));
-    $content = file_get_contents($file);
-    if (preg_match_all('/by-id\/(\S+)/', $content, $matches)) {
-      foreach ($matches[1] as $id) {
-        $pool_map["/dev/disk/by-id/$id"] = $pool;
+  // 获取 pool 名 → 挂载点路径
+  $mnt = array_filter(glob("/mnt/*"), 'is_dir');
+  $pools = [];
+  foreach ($mnt as $path) {
+    $base = basename($path);
+    if (in_array($base, ['user', 'disks', 'remotes'])) continue;
+    if (strpos($base, 'disk') === 0 || strpos($base, 'user') === 0) continue;
+    $pools[$base] = $path;
+  }
+
+  // 解析 lsblk 中 pool 对应设备
+  $dev_to_pool = [];
+  $lsblk = shell_exec("lsblk -pJ -o NAME,KNAME,MOUNTPOINT 2>/dev/null");
+  $blk = json_decode($lsblk, true);
+  foreach (($blk['blockdevices'] ?? []) as $dev) {
+    foreach (($dev['children'] ?? []) as $child) {
+      $mp = $child['mountpoint'] ?? '';
+      $kname = $child['kname'] ?? '';
+      foreach ($pools as $poolname => $poolmnt) {
+        if ($mp && strpos($mp, $poolmnt) === 0) {
+          $dev_to_pool["/dev/$kname"] = ucfirst($poolname);
+        }
       }
     }
   }
 
-  // 获取 /boot 的设备（排除）
-  $boot_mount = realpath("/boot");
-  $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
-  $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
+  // 忽略 /boot 所在设备
+  $boot_dev = exec("findmnt -n -o SOURCE --target /boot 2>/dev/null");
+  $boot_base = preg_replace('#[0-9]+$#', '', $boot_dev);
 
   foreach (glob("/dev/disk/by-id/*") as $dev) {
-    if (!is_link($dev) || strpos($dev, "part") !== false) continue;
+    if (!is_link($dev) || strpos($dev, 'part') !== false) continue;
     if (strpos(basename($dev), 'usb-') === 0) continue;
 
     $real = realpath($dev);
-    if ($real === false) continue;
-    if (strpos($real, $boot_dev_base) === 0) continue;
-    if (in_array($real, $seen)) continue;
+    if (!$real || in_array($real, $seen)) continue;
+    if (strpos($real, $boot_base) === 0) continue;
+
     $seen[] = $real;
-
     $id = basename($dev);
-    $id_clean = preg_replace('/^(ata|nvme)-/', '', $id);
-    $short = $id_clean;
+    $label = preg_replace('/^(nvme|ata)-/', '', $id);
+    $title = "$id\n$real";
 
-    // 获取 nvmeXn1 或 sdX
-    if (preg_match('#/dev/(nvme\d+n\d+|sd[a-z])#', $real, $m)) {
-      $dev_short = $m[1];
+    // 显示格式优化
+    if (preg_match('#/dev/([a-z0-9]+)[p]?[0-9]*$#', $real, $m)) {
+      $base = "/dev/" . $m[1];
+      if (isset($dev_to_diskx[$base])) {
+        $label = $dev_to_diskx[$base] . " - " . $label;
+        $group = "Array";
+      } elseif (isset($dev_to_pool[$real])) {
+        $label .= " ($m[1])";
+        $group = $dev_to_pool[$real];
+      } else {
+        $label .= " ($m[1])";
+        $group = "Others";
+      }
     } else {
-      $dev_short = basename($real);
+      $group = "Others";
     }
 
-    // 判断属于哪个组
-    $group = "Others";
-    $label = $short;
-
-    if (isset($dev_to_label[$real])) {
-      $group = "Array";
-      $label = $dev_to_label[$real] . " - $short";
-    } elseif (isset($pool_map[$dev])) {
-      $group = $pool_map[$dev];
-      $label = "$short ($dev_short)";
-    } else {
-      $label = "$short ($dev_short)";
-    }
-
-    $groups[$group][] = ['id' => $id, 'dev' => $real, 'label' => $label];
+    $groups[$group][] = ['id' => $id, 'dev' => $real, 'label' => $label, 'title' => $title];
   }
 
-  // 排序
+  // 排序：Array → 其他 pool → Others
   uksort($groups, function($a, $b) {
-    if ($a == "Array") return -1;
-    if ($b == "Array") return 1;
+    if ($a === 'Array') return -1;
+    if ($b === 'Array') return 1;
+    if ($a === 'Others') return 1;
+    if ($b === 'Others') return -1;
     return strnatcasecmp($a, $b);
   });
 
-  // 排序 Array 内部顺序
-  if (isset($groups["Array"])) {
-    usort($groups["Array"], function($a, $b) use ($array_order) {
-      $al = explode(" -", $a['label'])[0];
-      $bl = explode(" -", $b['label'])[0];
-      return ($array_order[$al] ?? 99) <=> ($array_order[$bl] ?? 99);
+  // 内部排序：Array 按 Disk 顺序，其他按 label
+  if (isset($groups['Array'])) {
+    usort($groups['Array'], function($a, $b) {
+      preg_match('/Disk (\d+)/', $a['label'], $ma);
+      preg_match('/Disk (\d+)/', $b['label'], $mb);
+      return ($ma[1] ?? 99) <=> ($mb[1] ?? 99);
     });
   }
+  foreach ($groups as $key => &$entries) {
+    if ($key !== 'Array') {
+      usort($entries, fn($a, $b) => strnatcasecmp($a['label'], $b['label']));
+    }
+  }
 
-  return $groups;  // 每组对应 optgroup -> list of [id, dev, label]
+  return $groups;
 }

--- a/include/Common.php
+++ b/include/Common.php
@@ -10,24 +10,6 @@ function list_pwm() {
     }
   }
 
-  // 按 pwm 名称排序（例如 pwm1, pwm2...）
-  usort($out, fn($a, $b) => strcmp($a['name'], $b['name']));
-  return $out;
-}
-
-<?php
-
-function list_pwm() {
-  $out = [];
-  exec("find /sys/devices -type f -iname 'pwm[0-9]' -exec dirname \"{}\" + | uniq", $chips);
-  foreach ($chips as $chip) {
-    $name = is_file("$chip/name") ? file_get_contents("$chip/name") : '';
-    foreach (glob("$chip/pwm[0-9]") as $pwm) {
-      $out[] = ['chip' => $name, 'name' => basename($pwm), 'sensor' => $pwm];
-    }
-  }
-
-  // 按 pwm 名称排序（例如 pwm1, pwm2...）
   usort($out, fn($a, $b) => strcmp($a['name'], $b['name']));
   return $out;
 }
@@ -35,23 +17,18 @@ function list_pwm() {
 function list_valid_disks_by_id() {
   $seen = [];
   $result = [];
-
-  // 建立 /dev/sdX 或 /dev/nvmeXn1 → diskX 的反向映射
   $dev_to_disk = [];
 
-  // 使用 lsblk 分析 /mnt/diskX 实际来源设备
   foreach (glob("/mnt/disk*") as $mnt) {
     $mountpoint = escapeshellarg($mnt);
-    $output = shell_exec("lsblk -no NAME,MOUNTPOINT /dev/md* 2>/dev/null");
-    // 手动逐行找出 mdXp1 -> diskX
+    $out = [];
     exec("findmnt -n -o SOURCE --target $mountpoint", $out);
-    if (!empty($out[0])) {
-      $src = trim($out[0]); // /dev/mdXp1
-      $parents = shell_exec("lsblk -no PKNAME $src 2>/dev/null");  // 可能返回 sdd
-      $parent = trim($parents);
+    $src = trim($out[0] ?? '');
+    if ($src) {
+      $parent = trim(shell_exec("lsblk -no PKNAME $src 2>/dev/null"));
       if ($parent && strpos($parent, 'loop') === false) {
         $base = "/dev/" . $parent;
-        $dev_to_disk[$base] = basename($mnt); // disk1, disk2...
+        $dev_to_disk[$base] = basename($mnt);
         error_log("[fanctrlplus] map $base ← " . basename($mnt));
       }
     }
@@ -75,57 +52,6 @@ function list_valid_disks_by_id() {
     $id = basename($dev);
     $label = $id;
 
-    // 从 /dev/sdX1 或 /dev/nvmeXn1p1 → /dev/sdX
-    if (preg_match('#/dev/([a-z0-9]+)[p]?[0-9]*$#', $real, $m)) {
-      $base = "/dev/" . $m[1];
-      if (isset($dev_to_disk[$base])) {
-        $label .= " → " . $dev_to_disk[$base];
-        error_log("[fanctrlplus] matched $base → {$dev_to_disk[$base]} for id=$id");
-      } else {
-        error_log("[fanctrlplus] no match for $base (id=$id)");function list_valid_disks_by_id() {
-  $seen = [];
-  $result = [];
-
-  // 建立 /dev/sdX 或 /dev/nvmeXn1 → diskX 的反向映射
-  $dev_to_disk = [];
-
-  // 使用 lsblk 分析 /mnt/diskX 实际来源设备
-  foreach (glob("/mnt/disk*") as $mnt) {
-    $mountpoint = escapeshellarg($mnt);
-    $output = shell_exec("lsblk -no NAME,MOUNTPOINT /dev/md* 2>/dev/null");
-    // 手动逐行找出 mdXp1 -> diskX
-    exec("findmnt -n -o SOURCE --target $mountpoint", $out);
-    if (!empty($out[0])) {
-      $src = trim($out[0]); // /dev/mdXp1
-      $parents = shell_exec("lsblk -no PKNAME $src 2>/dev/null");  // 可能返回 sdd
-      $parent = trim($parents);
-      if ($parent && strpos($parent, 'loop') === false) {
-        $base = "/dev/" . $parent;
-        $dev_to_disk[$base] = basename($mnt); // disk1, disk2...
-        error_log("[fanctrlplus] map $base ← " . basename($mnt));
-      }
-    }
-  }
-
-  $boot_mount = realpath("/boot");
-  $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
-  $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
-
-  foreach (glob("/dev/disk/by-id/*") as $dev) {
-    if (!is_link($dev) || strpos($dev, "part") !== false) continue;
-    if (strpos(basename($dev), 'usb-') === 0) continue;
-
-    $real = realpath($dev);
-    if ($real === false) continue;
-    if (strpos($real, "/dev/sd") === false && strpos($real, "/dev/nvme") === false) continue;
-    if (strpos($real, $boot_dev_base) === 0) continue;
-    if (in_array($real, $seen)) continue;
-
-    $seen[] = $real;
-    $id = basename($dev);
-    $label = $id;
-
-    // 从 /dev/sdX1 或 /dev/nvmeXn1p1 → /dev/sdX
     if (preg_match('#/dev/([a-z0-9]+)[p]?[0-9]*$#', $real, $m)) {
       $base = "/dev/" . $m[1];
       if (isset($dev_to_disk[$base])) {
@@ -133,19 +59,6 @@ function list_valid_disks_by_id() {
         error_log("[fanctrlplus] matched $base → {$dev_to_disk[$base]} for id=$id");
       } else {
         error_log("[fanctrlplus] no match for $base (id=$id)");
-      }
-    } else {
-      error_log("[fanctrlplus] no match regex for real=$real");
-    }
-
-    error_log("[fanctrlplus] disk id=$id real=$real label=$label");
-    $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
-  }
-
-  usort($result, fn($a, $b) => strnatcasecmp($a['id'], $b['id']));
-  error_log("[fanctrlplus] final disk list count: " . count($result));
-  return $result;
-}
       }
     } else {
       error_log("[fanctrlplus] no match regex for real=$real");

--- a/include/Common.php
+++ b/include/Common.php
@@ -27,9 +27,9 @@ function list_valid_disks_by_id() {
   $dev_to_disk = [];
   foreach (glob("/mnt/disk*") as $mnt) {
     $real = realpath($mnt);  // 会返回 /dev/mdX 或 /dev/sdX1
-    if ($real && preg_match('#/dev/(sd[a-z]+)[0-9]*$#', $real, $m)) {
-      $dev_base = "/dev/" . $m[1];  // 提取 /dev/sdX
-      $dev_to_disk[$dev_base] = basename($mnt);  // /dev/sdX → disk1
+    if ($real && preg_match('#/dev/(sd[a-z]+|md[0-9]+)[p0-9]*$#', $real, $m)) {
+      $dev_base = "/dev/" . $m[1];  // 支持 sdX 或 mdX
+      $dev_to_disk[$dev_base] = basename($mnt);  // /dev/md1 → disk1
     }
   }
 
@@ -48,13 +48,12 @@ function list_valid_disks_by_id() {
     $label = $id;
 
     // 追加 diskX 标签（通过 dev_base 匹配）
-    if (preg_match('#/dev/(sd[a-z]+)#', $real, $m)) {
+    if (preg_match('#/dev/(sd[a-z]+|md[0-9]+)#', $real, $m)) {
       $dev_base = "/dev/" . $m[1];
       if (isset($dev_to_disk[$dev_base])) {
         $label .= " → " . $dev_to_disk[$dev_base];
       }
     }
-
     $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
   }
 

--- a/include/Common.php
+++ b/include/Common.php
@@ -55,6 +55,7 @@ function list_valid_disks_by_id() {
     }
 
     $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
+    error_log("[fanctrlplus] match $real → "
   }
 
   usort($result, fn($a, $b) => strnatcasecmp($a['id'], $b['id']));

--- a/include/Common.php
+++ b/include/Common.php
@@ -19,20 +19,30 @@ function list_valid_disks_by_id() {
   $seen = [];
   $result = [];
 
+  // 建立 /dev/sdX 或 /dev/nvmeXn1 → diskX 的反向映射
+  $dev_to_disk = [];
+
+  // 使用 lsblk 分析 /mnt/diskX 实际来源设备
+  foreach (glob("/mnt/disk*") as $mnt) {
+    $mountpoint = escapeshellarg($mnt);
+    $output = shell_exec("lsblk -no NAME,MOUNTPOINT /dev/md* 2>/dev/null");
+    // 手动逐行找出 mdXp1 -> diskX
+    exec("findmnt -n -o SOURCE --target $mountpoint", $out);
+    if (!empty($out[0])) {
+      $src = trim($out[0]); // /dev/mdXp1
+      $parents = shell_exec("lsblk -no PKNAME $src 2>/dev/null");  // 可能返回 sdd
+      $parent = trim($parents);
+      if ($parent && strpos($parent, 'loop') === false) {
+        $base = "/dev/" . $parent;
+        $dev_to_disk[$base] = basename($mnt); // disk1, disk2...
+        error_log("[fanctrlplus] map $base ← " . basename($mnt));
+      }
+    }
+  }
+
   $boot_mount = realpath("/boot");
   $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
   $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
-
-  // 建立 diskX 映射（/mnt/diskX -> /dev/sdX）
-  $dev_to_disk = [];
-  foreach (glob("/mnt/disk*") as $mnt) {
-    $real = realpath($mnt);  // 如 /dev/mdXp1
-    if ($real && preg_match('#/dev/(sd[a-z]+)[0-9]*$#', $real, $m)) {
-      $base = "/dev/" . $m[1];  // /dev/sdX
-      $dev_to_disk[$base] = basename($mnt);  // disk1, disk2...
-      error_log("[fanctrlplus] map $base ← " . basename($mnt));
-    }
-  }
 
   foreach (glob("/dev/disk/by-id/*") as $dev) {
     if (!is_link($dev) || strpos($dev, "part") !== false) continue;
@@ -48,28 +58,24 @@ function list_valid_disks_by_id() {
     $id = basename($dev);
     $label = $id;
 
-    // 追加 diskX 标签（通过 dev_base 匹配）
-    if (preg_match('#/dev/(sd[a-z]+)#', $real, $m)) {
-      $dev_base = "/dev/" . $m[1];
-      if (isset($dev_to_disk[$dev_base])) {
-        $label .= " → " . $dev_to_disk[$dev_base];
-        error_log("[fanctrlplus] matched $dev_base → {$dev_to_disk[$dev_base]} for id=$id");
+    // 从 /dev/sdX1 或 /dev/nvmeXn1p1 → /dev/sdX
+    if (preg_match('#/dev/([a-z0-9]+)[p]?[0-9]*$#', $real, $m)) {
+      $base = "/dev/" . $m[1];
+      if (isset($dev_to_disk[$base])) {
+        $label .= " → " . $dev_to_disk[$base];
+        error_log("[fanctrlplus] matched $base → {$dev_to_disk[$base]} for id=$id");
       } else {
-        error_log("[fanctrlplus] no match for $dev_base (id=$id)");
+        error_log("[fanctrlplus] no match for $base (id=$id)");
       }
     } else {
-      error_log("[fanctrlplus] no sdX match for real=$real");
+      error_log("[fanctrlplus] no match regex for real=$real");
     }
 
     error_log("[fanctrlplus] disk id=$id real=$real label=$label");
-
     $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
   }
 
-  usort($result, function($a, $b) {
-    return strnatcasecmp($a['id'], $b['id']);
-  });
-
+  usort($result, fn($a, $b) => strnatcasecmp($a['id'], $b['id']));
   error_log("[fanctrlplus] final disk list count: " . count($result));
   return $result;
 }

--- a/include/Common.php
+++ b/include/Common.php
@@ -1,0 +1,36 @@
+<?php
+
+function list_pwm() {
+  $out = [];
+  exec("find /sys/devices -type f -iname 'pwm[0-9]' -exec dirname \"{}\" + | uniq", $chips);
+  foreach ($chips as $chip) {
+    $name = is_file("$chip/name") ? file_get_contents("$chip/name") : '';
+    foreach (glob("$chip/pwm[0-9]") as $pwm) {
+      $out[] = ['chip'=>$name, 'name'=>basename($pwm), 'sensor'=>$pwm];
+    }
+  }
+  return $out;
+}
+
+function list_valid_disks_by_id() {
+  $seen = [];
+  $result = [];
+
+  $boot_mount = realpath("/boot");
+  $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
+  $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
+
+  foreach (glob("/dev/disk/by-id/*") as $dev) {
+    if (!is_link($dev) || strpos($dev, "part") !== false) continue;
+    $real = realpath($dev);
+    if ($real === false) continue;
+    if (strpos($real, "/dev/sd") === false && strpos($real, "/dev/nvme") === false) continue;
+    if (strpos($real, $boot_dev_base) === 0) continue;
+    if (in_array($real, $seen)) continue;
+
+    $seen[] = $real;
+    $result[] = ['id' => basename($dev), 'dev' => $real];
+  }
+
+  return $result;
+}

--- a/include/Common.php
+++ b/include/Common.php
@@ -17,93 +17,66 @@ function list_pwm() {
 function list_valid_disks_by_id() {
   $seen = [];
   $result = [];
-  $dev_to_disk = [];
+  $dev_to_diskx = [];
 
-  // 构建 dev -> diskX 映射（包括 Parity）
-  $lsblk_json = shell_exec("lsblk -pJ -o NAME,KNAME,MOUNTPOINT 2>/dev/null");
-  $blk = json_decode($lsblk_json, true);
-  if (!empty($blk['blockdevices'])) {
-    foreach ($blk['blockdevices'] as $dev) {
-      $mp = $dev['mountpoint'] ?? '';
-      $kname = $dev['kname'] ?? '';
-      if ($mp && preg_match('#^/mnt/disk[0-9]+$#', $mp)) {
-        $diskX = basename($mp);
-        $parent = trim(shell_exec("lsblk -no PKNAME $kname 2>/dev/null"));
-        if ($parent) {
-          $dev_to_disk["/dev/$parent"] = $diskX;
-        }
+  // 1. 建立 /dev/sdX → diskX/parity 映射
+  $lines = shell_exec("/usr/local/sbin/mdcmd status | grep rdevName");
+  foreach (explode("\n", $lines) as $line) {
+    if (preg_match('/rdevName\.(\d+)=(\w+)/', $line, $m)) {
+      $slot = intval($m[1]);
+      $dev  = "/dev/" . trim($m[2]);
+      if ($slot == 0) {
+        $dev_to_diskx[$dev] = "Parity";
+      } elseif ($slot == 29) {
+        $dev_to_diskx[$dev] = "Parity 2";
+      } else {
+        $dev_to_diskx[$dev] = "Disk " . $slot;
       }
     }
   }
 
-  // 加入 Parity/Parity2 映射
-  $mdstat = @file_get_contents("/proc/mdstat");
-  if ($mdstat !== false) {
-    foreach (explode("\n", $mdstat) as $line) {
-      if (preg_match('#^md([0-9]+) : .*#', $line, $m)) {
-        $md = "md{$m[1]}";
-        $out = shell_exec("/usr/local/sbin/mdcmd status | grep -i 'rdevName.*='");
-        foreach (explode("\n", $out) as $entry) {
-          if (preg_match('#rdevName\\.[0-9]+=([^\\s]+)#', $entry, $m2)) {
-            $dev = "/dev/" . trim($m2[1]);
-            if (!isset($dev_to_disk[$dev])) {
-              $dev_to_disk[$dev] = ($m[1] == "1") ? "Parity" : "Parity 2";
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // 获取启动盘（用于排除）
+  // 2. 获取 /boot 的设备（跳过它）
   $boot_mount = realpath("/boot");
   $boot_dev = exec("findmnt -n -o SOURCE --target $boot_mount 2>/dev/null");
   $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
 
-  // 遍历 by-id 设备
+  // 3. 遍历所有 by-id
   foreach (glob("/dev/disk/by-id/*") as $dev) {
     if (!is_link($dev) || strpos($dev, "part") !== false) continue;
     if (strpos(basename($dev), 'usb-') === 0) continue;
 
     $real = realpath($dev);
-    if ($real === false) continue;
-    if (strpos($real, "/dev/sd") === false && strpos($real, "/dev/nvme") === false) continue;
+    if ($real === false || in_array($real, $seen)) continue;
     if (strpos($real, $boot_dev_base) === 0) continue;
-    if (in_array($real, $seen)) continue;
 
     $seen[] = $real;
     $id = basename($dev);
-    $short = preg_replace('#^(ata|nvme)-#', '', $id); // 去除前缀
+    $clean_id = preg_replace('/^(ata|nvme)-/', '', $id); // 去前缀
 
-    $label = $short;
+    // 判断是否为 sdX/nvmeXn1，并匹配 dev_to_diskx
+    $label = $clean_id;
+    $sort_key = "Z-" . $clean_id; // 默认排最后（未识别的 NVMe）
+
     if (preg_match('#/dev/([a-z0-9]+)[p]?[0-9]*$#', $real, $m)) {
       $base = "/dev/" . $m[1];
-      if (isset($dev_to_disk[$base])) {
-        $label .= " → " . $dev_to_disk[$base];
-      } elseif (strpos($real, '/dev/nvme') === 0) {
-        $label .= " (" . basename($real) . ")";
+      if (isset($dev_to_diskx[$base])) {
+        $diskx = $dev_to_diskx[$base];
+        $label = "$diskx - $clean_id";
+        $sort_key = str_pad($diskx === 'Parity' ? 0 : ($diskx === 'Parity 2' ? 1 : intval(preg_replace('/\D/', '', $diskx)) + 10), 3, '0', STR_PAD_LEFT);
+      } else {
+        // 未映射（通常是 NVMe）
+        $shortname = basename($real);
+        $label = "$clean_id ($shortname)";
       }
     }
 
-    $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
+    error_log("[fanctrlplus] disk id=$id real=$real label=$label sort=$sort_key");
+    $result[] = ['id' => $id, 'dev' => $real, 'label' => $label, 'sort' => $sort_key];
   }
 
-  // 排序规则：先 Parity，再 Disk1~N，最后其它
-  usort($result, function($a, $b) {
-    $map = ['Parity' => 0, 'Parity 2' => 1];
-    $a_priority = 999;
-    $b_priority = 999;
-
-    foreach ($map as $key => $val) {
-      if (strpos($a['label'], $key) !== false) $a_priority = $val;
-      if (strpos($b['label'], $key) !== false) $b_priority = $val;
-    }
-
-    if (preg_match('/→ disk(\\d+)/i', $a['label'], $ma)) $a_priority = 10 + (int)$ma[1];
-    if (preg_match('/→ disk(\\d+)/i', $b['label'], $mb)) $b_priority = 10 + (int)$mb[1];
-
-    return $a_priority <=> $b_priority;
-  });
-
+  // 4. 排序
+  usort($result, fn($a, $b) => strnatcasecmp($a['sort'], $b['sort']));
+  foreach ($result as &$r) unset($r['sort']); // 清理临时排序键
+  error_log("[fanctrlplus] final sorted disk list count: " . count($result));
   return $result;
 }

--- a/include/Common.php
+++ b/include/Common.php
@@ -19,18 +19,14 @@ function list_valid_disks_by_id() {
   $result = [];
   $dev_to_disk = [];
 
-  // 构建 /dev/sdX → diskX 映射（Unraid array）
-  foreach (glob("/mnt/disk*") as $mnt) {
-    $out = [];
-    exec("findmnt -n -o SOURCE --target " . escapeshellarg($mnt), $out);
-    if (!empty($out[0])) {
-      $src = trim($out[0]);  // e.g. /dev/md1p1
-      $pk = trim(shell_exec("lsblk -no PKNAME $src 2>/dev/null"));  // e.g. sdd
-      if ($pk && strpos($pk, 'loop') === false) {
-        $base = "/dev/$pk";
-        $dev_to_disk[$base] = basename($mnt);  // disk1, disk2
-        error_log("[fanctrlplus] map $base ← " . basename($mnt));
-      }
+  // 用 lsblk 找出 /mnt/diskX 的底层设备
+  exec("lsblk -P -o NAME,KNAME,MOUNTPOINT", $lines);
+  foreach ($lines as $line) {
+    if (preg_match('/KNAME="([^"]+)" MOUNTPOINT="\/mnt\/(disk[0-9]+)"/', $line, $m)) {
+      $dev = "/dev/" . $m[1];
+      $disk = $m[2];
+      $dev_to_disk[$dev] = $disk;
+      error_log("[fanctrlplus] map $dev ← $disk");
     }
   }
 
@@ -39,12 +35,11 @@ function list_valid_disks_by_id() {
   $boot_dev_base = preg_replace('#[0-9]+$#', '', $boot_dev);
 
   foreach (glob("/dev/disk/by-id/*") as $dev) {
-    if (!is_link($dev) || strpos($dev, 'part') !== false) continue;
+    if (!is_link($dev) || strpos($dev, "part") !== false) continue;
     if (strpos(basename($dev), 'usb-') === 0) continue;
 
-    $real = readlink($dev);
+    $real = realpath($dev);
     if ($real === false) continue;
-    $real = "/dev/" . basename($real);  // e.g. /dev/sdd1
     if (strpos($real, "/dev/sd") === false && strpos($real, "/dev/nvme") === false) continue;
     if (strpos($real, $boot_dev_base) === 0) continue;
     if (in_array($real, $seen)) continue;
@@ -61,15 +56,12 @@ function list_valid_disks_by_id() {
       } else {
         error_log("[fanctrlplus] no match for $base (id=$id)");
       }
-    } else {
-      error_log("[fanctrlplus] regex fail for real=$real");
     }
 
-    error_log("[fanctrlplus] disk id=$id real=$real label=$label");
     $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
   }
 
-  error_log("[fanctrlplus] final disk list count: " . count($result));
   usort($result, fn($a, $b) => strnatcasecmp($a['id'], $b['id']));
+  error_log("[fanctrlplus] final disk list count: " . count($result));
   return $result;
 }

--- a/include/Common.php
+++ b/include/Common.php
@@ -10,9 +10,11 @@ function list_pwm() {
     }
   }
 
+  // 按 pwm 名称排序（例如 pwm1, pwm2...）
   usort($out, fn($a, $b) => strcmp($a['name'], $b['name']));
   return $out;
 }
+
 function list_valid_disks_by_id() {
   $seen = [];
   $result = [];
@@ -51,34 +53,6 @@ function list_valid_disks_by_id() {
       if (isset($dev_to_disk[$dev_base])) {
         $label .= " → " . $dev_to_disk[$dev_base];
       }
-    }
-
-    $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];
-  }
-
-  usort($result, function($a, $b) {
-    return strnatcasecmp($a['id'], $b['id']);
-  });
-
-  return $result;
-}
-
-  foreach (glob("/dev/disk/by-id/*") as $dev) {
-    if (!is_link($dev) || strpos($dev, "part") !== false) continue;
-    if (strpos(basename($dev), 'usb-') === 0) continue;
-
-    $real = realpath($dev);
-    if ($real === false) continue;
-    if (strpos($real, "/dev/sd") === false && strpos($real, "/dev/nvme") === false) continue;
-    if (strpos($real, $boot_dev_base) === 0) continue;
-    if (in_array($real, $seen)) continue;
-
-    $seen[] = $real;
-    $id = basename($dev);
-    $label = $id;
-
-    if (isset($sd_to_disk[$real])) {
-      $label .= " → " . $sd_to_disk[$real];  // ✅ 显示 disk1、disk2
     }
 
     $result[] = ['id' => $id, 'dev' => $real, 'label' => $label];

--- a/include/FanBlockRender.php
+++ b/include/FanBlockRender.php
@@ -1,63 +1,88 @@
 <?php
 function render_fan_block($cfg, $i, $pwms, $disks) {
   error_log("[fanctrlplus] render_fan_block called with cfg: " . json_encode($cfg));
+
   ob_start();
   ?>
   <div class="fan-block" style="display:inline-block; width:48%; vertical-align:top;">
-    <input type="hidden" name="#file[<?=$i?>]" value="<?=$cfg['file']?>" class="cfg-file">
+    <input type="hidden" name="#file[<?=$i?>]" value="<?=htmlspecialchars($cfg['file'])?>" class="cfg-file">
+
     <fieldset style="margin:10px 0; padding:34px 16px 12px 16px; border:1px solid #ccc; border-radius:6px; position:relative;">
       <span class="fan-status" style="position:absolute; top:6px; right:8px;">🔄</span>
       <button type="button" onclick="removeFan(this)" title="Delete this fan configuration" style="position:absolute; bottom:6px; right:8px;">DELETE</button>
+
       <table style="width:100%;">
         <tr>
           <td style="cursor: help;" title="Enter a unique name for this fan. Avoid spaces or special characters.">Custom Name</td>
-          <td><input type="text" name="custom[<?=$i?>]" value="<?=htmlspecialchars($cfg['custom']??'')?>" placeholder="Required (e.g. HDDBay)" required></td>
+          <td>
+            <input type="text" name="custom[<?=$i?>]" value="<?=htmlspecialchars($cfg['custom'] ?? '')?>" placeholder="Required (e.g. HDDBay)" required>
+          </td>
         </tr>
+
         <tr>
           <td style="cursor: help;" title="Enable or disable this fan controller">Fan Control:</td>
           <td>
             <select name="service[<?=$i?>]">
-              <option value="0" <?=($cfg['service']??'')=='0'?'selected':''?>>Disabled</option>
-              <option value="1" <?=($cfg['service']??'')=='1'?'selected':''?>>Enabled</option>
+              <option value="0" <?=($cfg['service'] ?? '') == '0' ? 'selected' : ''?>>Disabled</option>
+              <option value="1" <?=($cfg['service'] ?? '') == '1' ? 'selected' : ''?>>Enabled</option>
             </select>
           </td>
         </tr>
+
         <tr>
           <td style="cursor: help;" title="Select the PWM controller for this fan">PWM Controller:</td>
           <td>
             <select name="controller[<?=$i?>]">
               <?php foreach ($pwms as $pwm): ?>
-              <option value="<?=$pwm['sensor']?>" <?=($cfg['controller']??'')==$pwm['sensor']?'selected':''?>><?=$pwm['chip']?> - <?=$pwm['name']?></option>
+                <option value="<?=$pwm['sensor']?>" <?=($cfg['controller'] ?? '') == $pwm['sensor'] ? 'selected' : ''?>>
+                  <?=$pwm['chip']?> - <?=$pwm['name']?>
+                </option>
               <?php endforeach; ?>
             </select>
             <button type="button" onclick="pauseFan($(this).prev().val(), this)" title="Pause this fan for 30 seconds to identify its location.">Pause 30s</button>
           </td>
         </tr>
+
         <tr>
           <td style="cursor: help;" title="Set the minimum PWM value (0–255)">Min PWM:</td>
-          <td><input type="text" name="pwm[<?=$i?>]" value="<?=htmlspecialchars($cfg['pwm']??'')?>"></td>
+          <td>
+            <input type="number" name="pwm[<?=$i?>]" value="<?=htmlspecialchars($cfg['pwm'] ?? '')?>">
+          </td>
         </tr>
+
         <tr>
           <td style="cursor: help;" title="At or below this temperature, fan will run at the configured minimum PWM">Low Temp (°C):</td>
-          <td><input type="number" name="low[<?=$i?>]" value="<?=htmlspecialchars($cfg['low']??'')?>"></td>
+          <td>
+            <input type="number" name="low[<?=$i?>]" value="<?=htmlspecialchars($cfg['low'] ?? '')?>">
+          </td>
         </tr>
+
         <tr>
           <td style="cursor: help;" title="At or above this temperature, fan will run at the configured maximum PWM">High Temp (°C):</td>
-          <td><input type="number" name="high[<?=$i?>]" value="<?=htmlspecialchars($cfg['high']??'')?>"></td>
+          <td>
+            <input type="number" name="high[<?=$i?>]" value="<?=htmlspecialchars($cfg['high'] ?? '')?>">
+          </td>
         </tr>
+
         <tr>
           <td style="cursor: help;" title="Check temperature and adjust fan speed every X minutes.">Interval (min):</td>
-          <td><input type="number" name="interval[<?=$i?>]" value="<?=htmlspecialchars($cfg['interval']??'')?>"></td>
+          <td>
+            <input type="number" name="interval[<?=$i?>]" value="<?=htmlspecialchars($cfg['interval'] ?? '')?>">
+          </td>
         </tr>
+
         <tr>
           <td style="cursor: help;" title="Select disk(s) to monitor for temperature control.">Include Disk(s):</td>
           <td>
             <select class="disk-select" name="disks[<?=$i?>][]" multiple style="width:400px;">
-              <?php foreach ($disks as $d):
+              <?php
+              $selected = explode(',', $cfg['disks'] ?? '');
+              foreach ($disks as $d):
                 $id = $d['id'];
-                $sel = in_array($id, explode(',', $cfg['disks']??'')) ? 'selected' : '';
+                $dev = $d['dev'];
+                $sel = in_array($id, $selected) ? 'selected' : '';
               ?>
-              <option value="<?=$id?>" <?=$sel?>><?=$id?> → <?=$d['dev']?></option>
+                <option value="<?=$id?>" <?=$sel?> title="<?=$id?>\n<?=$dev?>"><?=$id?> → <?=$dev?></option>
               <?php endforeach; ?>
             </select>
           </td>
@@ -66,4 +91,9 @@ function render_fan_block($cfg, $i, $pwms, $disks) {
     </fieldset>
   </div>
   <?php
-  return ob_get_clean();
+  $html = ob_get_contents();
+  ob_end_clean();
+
+  error_log("[fanctrlplus] rendered HTML length: " . strlen($html));
+  return $html;
+}

--- a/include/FanBlockRender.php
+++ b/include/FanBlockRender.php
@@ -82,7 +82,7 @@ function render_fan_block($cfg, $i, $pwms, $disks) {
                 $dev = $d['dev'];
                 $sel = in_array($id, $selected) ? 'selected' : '';
               ?>
-                <option value="<?=$id?>" <?=$sel?> title="<?=$id?>\n<?=$dev?>"><?=$id?> → <?=$dev?></option>
+                <option value="<?=$id?>" <?=$sel?> title="<?=$id?>&#10;<?=$dev?>"><?=$d['label']?></option>
               <?php endforeach; ?>
             </select>
           </td>

--- a/include/FanBlockRender.php
+++ b/include/FanBlockRender.php
@@ -77,12 +77,16 @@ function render_fan_block($cfg, $i, $pwms, $disks) {
             <select class="disk-select" name="disks[<?=$i?>][]" multiple style="width:400px;">
               <?php
               $selected = explode(',', $cfg['disks'] ?? '');
-              foreach ($disks as $d):
-                $id = $d['id'];
-                $dev = $d['dev'];
-                $sel = in_array($id, $selected) ? 'selected' : '';
+              $disk_groups = list_valid_disks_by_id();
+              foreach ($disk_groups as $group => $entries):
               ?>
-                <option value="<?=$id?>" <?=$sel?> title="<?=$id?>&#10;<?=$dev?>"><?=$d['label']?></option>
+                <optgroup label="<?=htmlspecialchars($group)?>">
+                  <?php foreach ($entries as $disk):
+                    $sel = in_array($disk['id'], $selected) ? 'selected' : '';
+                  ?>
+                    <option value="<?=$disk['id']?>" <?=$sel?> title="<?=$disk['id']?>&#10;<?=$disk['dev']?>"><?=htmlspecialchars($disk['label'])?></option>
+                  <?php endforeach; ?>
+                </optgroup>
               <?php endforeach; ?>
             </select>
           </td>

--- a/include/FanBlockRender.php
+++ b/include/FanBlockRender.php
@@ -1,6 +1,5 @@
 <?php
 function render_fan_block($cfg, $i, $pwms, $disks) {
-  error_log("[fanctrlplus] render_fan_block called with cfg: " . json_encode($cfg));
 
   ob_start();
   ?>
@@ -98,6 +97,5 @@ function render_fan_block($cfg, $i, $pwms, $disks) {
   $html = ob_get_contents();
   ob_end_clean();
 
-  error_log("[fanctrlplus] rendered HTML length: " . strlen($html));
   return $html;
 }

--- a/include/FanctrlLogic.php
+++ b/include/FanctrlLogic.php
@@ -144,7 +144,6 @@ switch ($op) {
     }
   
     require_once "$docroot/plugins/$plugin/include/FanBlockRender.php";
-    require_once "$docroot/plugins/$plugin/fanctrlplus.page"; // ✅ 加这个
   
     $pwms = list_pwm();
     $disks = list_valid_disks_by_id();

--- a/include/FanctrlLogic.php
+++ b/include/FanctrlLogic.php
@@ -5,6 +5,8 @@ ini_set('display_errors', 1);
 $plugin  = 'fanctrlplus';
 $docroot = $docroot ?? $_SERVER['DOCUMENT_ROOT'] ?: '/usr/local/emhttp';
 
+require_once "$docroot/plugins/$plugin/include/Common.php";
+
 header('Content-Type: application/json');
 
 function json_response($data) {
@@ -20,25 +22,6 @@ function scan_dir($dir) {
   $out = [];
   foreach (array_diff(scandir($dir), ['.','..']) as $f) {
     $out[] = realpath($dir) . '/' . $f;
-  }
-  return $out;
-}
-
-function list_fan() {
-  $out = [];
-  exec("find /sys/devices -type f -iname 'fan[0-9]_input' -exec dirname \"{}\" + | uniq", $chips);
-  foreach ($chips as $chip) {
-    $name = is_file("$chip/name") ? @file_get_contents("$chip/name") : false;
-    if ($name) {
-      foreach (preg_grep("/fan\d+_input/", scan_dir($chip)) as $fan) {
-        $out[] = [
-          'chip'   => $name,
-          'name'   => basename($fan),
-          'sensor' => $fan,
-          'rpm'    => @file_get_contents($fan)
-        ];
-      }
-    }
   }
   return $out;
 }

--- a/include/FanctrlLogic.php
+++ b/include/FanctrlLogic.php
@@ -135,7 +135,6 @@ switch ($op) {
     $disks = list_valid_disks_by_id();
   
     echo render_fan_block($cfg, $index, $pwms, $disks);  // ✅ 改为传完整 $cfg
-    error_log("[fanctrlplus] newtemp block output success");
     exit;
 
   case 'delete':
@@ -160,7 +159,6 @@ switch ($op) {
       }
     }
   
-    error_log("[fanctrlplus] status result: " . ($running ? 'running' : 'stopped'));
     json_response(['status' => $running ? 'running' : 'stopped']);
     break;
 
@@ -191,7 +189,6 @@ switch ($op) {
       }
     }
   
-    error_log("[fanctrlplus] status_all result: " . json_encode($result));
     json_response($result);
     break;
 

--- a/include/FanctrlLogic.php
+++ b/include/FanctrlLogic.php
@@ -120,6 +120,7 @@ switch ($op) {
 
   case 'newtemp':
     $index = $_REQUEST['index'] ?? 0;
+    $cfg_dir = "/boot/config/plugins/$plugin";
     $temp_file = "$cfg_dir/{$plugin}_temp_$index.cfg";
   
     if (!file_exists($temp_file)) {
@@ -128,10 +129,12 @@ switch ($op) {
   
     require_once "$docroot/plugins/$plugin/include/FanBlockRender.php";
   
+    $cfg = parse_ini_file($temp_file);             // ✅ 加载 temp 配置
+    $cfg['file'] = basename($temp_file);           // ✅ 加入 file 字段
     $pwms = list_pwm();
     $disks = list_valid_disks_by_id();
   
-    echo render_fan_block(basename($temp_file), $index, $pwms, $disks);
+    echo render_fan_block($cfg, $index, $pwms, $disks);  // ✅ 改为传完整 $cfg
     error_log("[fanctrlplus] newtemp block output success");
     exit;
 

--- a/include/update.fanctrlplus.php
+++ b/include/update.fanctrlplus.php
@@ -55,6 +55,7 @@ foreach ($_POST['#file'] as $i => $file) {
   // 拼接配置内容
   $cfg = [
     'custom'     => $custom,
+    'label'      => $custom,
     'service'    => $_POST['service'][$i] ?? '0',
     'controller' => $controller,
     'pwm'        => $_POST['pwm'][$i] ?? '',

--- a/scripts/rc.fanctrlplus
+++ b/scripts/rc.fanctrlplus
@@ -1,33 +1,36 @@
 #!/bin/bash
 
-plugin=fanctrlplus
+plugin="fanctrlplus"
 cfg_path="/boot/config/plugins/$plugin"
 loop_script="/usr/local/emhttp/plugins/$plugin/scripts/fanctrlplus_loop.sh"
 pid_dir="/var/run"
 
 fanctrlplus.start() {
   pkill -f "$loop_script" 2>/dev/null
+
   for cfg in "$cfg_path"/${plugin}_*.cfg; do
+    [[ -f "$cfg" ]] || continue
+
     service=$(grep -Po '^service="\K[^"]+' "$cfg")
     [[ "$service" != "1" ]] && continue
 
-    # 清洗 custom 值
+    # 取出并清洗 custom 名称（作为 pid 文件名一部分）
     raw_custom=$(grep -Po '^custom="\K[^"]+' "$cfg")
     clean_custom=$(echo "$raw_custom" | tr -d '\r\n\t ')
-    custom_safe=$(echo "$clean_custom" | tr -cd '[:alnum:]')
+    custom_safe=$(echo "$clean_custom" | tr -cd '[:alnum:]_-')
 
     [[ -z "$custom_safe" ]] && continue
 
     nohup "$loop_script" "$cfg" > /dev/null 2>&1 &
     echo $! > "$pid_dir/${plugin}_${custom_safe}.pid"
-    logger -t $plugin "Started [$custom_safe] from $cfg"
+    logger -t "$plugin" "Started [$custom_safe] from $cfg"
   done
 }
 
 fanctrlplus.stop() {
   pkill -f "$loop_script"
   rm -f "$pid_dir"/${plugin}_*.pid
-  logger -t $plugin "All fanctrlplus stopped"
+  logger -t "$plugin" "All fanctrlplus stopped"
 }
 
 fanctrlplus.status() {
@@ -45,11 +48,11 @@ fanctrlplus.status() {
 case "$1" in
   start) fanctrlplus.start ;;
   stop) fanctrlplus.stop ;;
-  status) fanctrlplus.status ;;
   restart)
     fanctrlplus.stop
     sleep 1
     fanctrlplus.start
     ;;
+  status) fanctrlplus.status ;;
   *) echo "Usage: $0 {start|stop|restart|status}" ;;
 esac


### PR DESCRIPTION
fanctrlplus v1.2.0 - Grouped Disk Selection & UI Optimization

What’s New:
	•	Grouped Disk Selector:
Disks in the “Include Disk(s)” dropdown are now grouped by:
	•	Array (Parity, Disk 1~N)
	•	ZFS cache pools (e.g., Cache, Seedcache, Torrentcache)
	•	Others for unrecognized devices
	•	Improved Sorting:
Within the Array group:
	•	Parity and Parity 2 are listed at the top
	•	Disks are sorted in natural numerical order
	•	Dynamic UI Rendering:
	•	The grouped disk list is generated dynamically using FanBlockRender.php
	•	Template-based fan block rendering (template.php) is now deprecated and unused
	•	Cleanup & Maintenance:
	•	Removed unnecessary debug logs
	•	Unified labeling format for dropdown options and logs

This version introduces better clarity and usability when selecting disks, especially for systems with multiple pools or NVMe devices.
