### PR TITLE
Release 1.2.1

### DIFF
--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -115,21 +115,31 @@ $(function() {
       btn.prop('disabled', false);
     });
   };
-
+  
   window.pauseFan = function(pwm, btn) {
-    $(btn).prop('disabled', true).text("Pausing...");
-    $.get('/plugins/fanctrlplus/include/FanctrlLogic.php', {op:'pause', pwm:pwm}, function() {
-      let seconds = 30;
-      let interval = setInterval(function() {
-        if (seconds <= 0) {
-          clearInterval(interval);
-          $(btn).text("Pause 30s").prop('disabled', false);
-        } else {
-          $(btn).text("Paused (" + seconds + "s)");
-          seconds--;
-        }
-      }, 1000);
-    });
+    if (!pwm || !btn) return;
+    
+    const $btn = $(btn);
+    $btn.prop('disabled', true).text("Pausing...");
+  
+    $.get('/plugins/fanctrlplus/include/FanctrlLogic.php', {op:'pause', pwm:pwm})
+      .done(function(data) {
+        console.log("✅ Pause triggered for", pwm, data);
+        let seconds = 30;
+        const interval = setInterval(() => {
+          if (seconds <= 0) {
+            clearInterval(interval);
+            $btn.text("Pause 30s").prop('disabled', false);
+          } else {
+            $btn.text(`Paused (${seconds}s)`);
+            seconds--;
+          }
+        }, 1000);
+      })
+      .fail(function(xhr, status, err) {
+        console.error("❌ Pause failed", status, err);
+        $btn.text("Pause 30s").prop('disabled', false);
+      });
   };
 
   window.removeFan = function(btn) {

--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -118,13 +118,17 @@ $(function() {
   
   window.pauseFan = function(pwm, btn) {
     if (!pwm || !btn) return;
-    
+  
     const $btn = $(btn);
     $btn.prop('disabled', true).text("Pausing...");
   
-    $.get('/plugins/fanctrlplus/include/FanctrlLogic.php', {op:'pause', pwm:pwm})
-      .done(function(data) {
-        console.log("✅ Pause triggered for", pwm, data);
+    $.ajax({
+      url: '/plugins/fanctrlplus/include/FanctrlLogic.php',
+      method: 'GET',
+      data: {op: 'pause', pwm: pwm},
+      timeout: 1000,
+      success: function(data) {
+        console.log("✅ Pause response:", data);
         let seconds = 30;
         const interval = setInterval(() => {
           if (seconds <= 0) {
@@ -135,11 +139,12 @@ $(function() {
             seconds--;
           }
         }, 1000);
-      })
-      .fail(function(xhr, status, err) {
-        console.error("❌ Pause failed", status, err);
+      },
+      error: function(xhr, status, err) {
+        console.error("❌ Pause failed:", status, err);
         $btn.text("Pause 30s").prop('disabled', false);
-      });
+      }
+    });
   };
 
   window.removeFan = function(btn) {

--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -35,7 +35,7 @@ $width = 300;
 ?>
 
 <p style="margin: 4px 0 12px 12px; font-size:13px; font-weight:normal;">
-  <span style="font-weight:bold;">Fan Control:</span>
+  <span style="font-weight:normal;">Fan Control:</span>
   <span id="status-value" style="color:green;">Active</span>
 </p>
 

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -45,10 +45,10 @@ fi
 
 echo ""
 echo "-----------------------------------------------------------"
-echo " Plugin &name is installed."
+echo " Plugin &name; is installed."
 echo " Array monitor is running."
-echo " Author: &author"
-echo " Version: &version"
+echo " Author: &author;"
+echo " Version: &version;"
 echo "-----------------------------------------------------------"
 echo ""
 exit 0

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -63,7 +63,6 @@ exit 0
 /usr/local/emhttp/plugins/fanctrlplus/scripts/rc.fanctrlplus stop 2>/dev/null
 pkill -f array_monitor.sh
 
-removepkg fanctrlplus
 rm -rf /usr/local/emhttp/plugins/fanctrlplus
 rm -rf /boot/config/plugins/fanctrlplus
 

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE PLUGIN [
   <!ENTITY name "fanctrlplus">
-  <!ENTITY version "1.2.0">
+  <!ENTITY version "1.2.1">
   <!ENTITY author "ck9393">
   <!ENTITY launch "Settings/fanctrlplus">
   <!ENTITY txz "/boot/config/plugins/&name;/fanctrlplus-&version;.txz">
@@ -79,6 +79,8 @@ exit 0
   <CHANGES>
 Release Notes – ###&version;
 
+- Fixed: "Pause 30s" button UI now properly counts down and resets after resuming fan.
+- Improved: Parity and Parity 2 are now correctly ordered in the disk dropdown (Parity → Parity 2 → Disk X).
 
   </CHANGES>
 </PLUGIN>

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -38,7 +38,7 @@ rm -f /boot/config/plugins/fanctrlplus/fanctrlplus-*.txz
     <INLINE>
 #!/bin/bash
 go_file="/boot/config/go"
-startup_line="/usr/local/emhttp/plugins/fanctrlplus/scripts/rc.autofan start &amp;
+startup_line="/usr/local/emhttp/plugins/fanctrlplus/scripts/rc.autofan start &amp;"
 
 # 如果 go 文件中不存在这一行，就添加
 grep -qF "$startup_line" "$go_file" || echo "$startup_line" >> "$go_file"

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -77,7 +77,7 @@ exit 0
   </FILE>
 
   <CHANGES>
-Release Notes – ###&verion;
+Release Notes – ###&version;
 
 
   </CHANGES>

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -5,7 +5,7 @@
   <!ENTITY author "ck9393">
   <!ENTITY launch "Settings/fanctrlplus">
   <!ENTITY txz "/boot/config/plugins/&name;/fanctrlplus-&version;.txz">
-  <!ENTITY pluginURL "https://github.com/ck9393/fanctrlplus/releases/download/v&version;/fanctrlplus-&version;.txz">
+  <!ENTITY pluginURL "https://github.com/ck9393/fanctrlplus/releases/download/v1.2.0/fanctrlplus-1.2.0.txz">
 ]>
 
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.9.0">

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -33,24 +33,20 @@ rm -f /boot/config/plugins/fanctrlplus/fanctrlplus-*.txz
     <URL>&url;</URL>
   </FILE>
 
-  <!-- 延迟启动 fanctrlplus 脚本，避免卡 WebUI -->
-  <FILE Name="/tmp/start_fanctrlplus" Mode="0770">
-    <INLINE>
-#!/bin/bash
-/usr/local/emhttp/plugins/fanctrlplus/scripts/rc.autofan start 2>/dev/null
-    </INLINE>
-  </FILE>
-
+  <!-- 开机自启：写入 /boot/config/go -->
   <FILE Run="/bin/bash">
     <INLINE>
 #!/bin/bash
-at -M -f /tmp/start_fanctrlplus now 2>/dev/null
-rm -f /tmp/start_fanctrlplus
+go_file="/boot/config/go"
+startup_line="/usr/local/emhttp/plugins/fanctrlplus/scripts/rc.autofan start &"
+
+# 如果 go 文件中不存在这一行，就添加
+grep -qF "$startup_line" "$go_file" || echo "$startup_line" >> "$go_file"
 
 echo ""
 echo "-----------------------------------------------------------"
 echo " Plugin fanctrlplus is installed."
-echo " This plugin requires Dynamix webGui to operate"
+echo " Auto-start entry added to /boot/config/go"
 echo " Author: ck9393"
 echo " Version: 1.2.0"
 echo "-----------------------------------------------------------"
@@ -67,7 +63,11 @@ exit 0
 removepkg fanctrlplus
 rm -rf /usr/local/emhttp/plugins/fanctrlplus
 rm -rf /boot/config/plugins/fanctrlplus
-echo "[fanctrlplus] Plugin removed."
+
+# 清除 go 文件中的自启动行
+sed -i '\|fanctrlplus/scripts/rc.autofan start|d' /boot/config/go
+
+echo "[fanctrlplus] Plugin removed and go entry cleaned."
 exit 0
     </INLINE>
   </FILE>
@@ -88,9 +88,9 @@ Release Notes – v1.2.0
 	•	Unraid flash drive is excluded from selection
 	•	Uses /dev/disk/by-id to ensure stable device mapping
 
-3. Other changes
-	•	Faster page loading and smoother UI interactions
-	•	Updated plugin structure and cleaner installation method
+3. Auto-start improvement
+	•	Plugin now auto-starts on boot via /boot/config/go entry
+	•	No longer uses temporary at-based delayed startup
 
 ⸻
 

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -76,7 +76,7 @@ exit 0
   </FILE>
 
   <CHANGES>
-Release Notes – ###&verion
+Release Notes – ###&verion;
 
 
   </CHANGES>

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -43,17 +43,17 @@ script="/usr/local/emhttp/plugins/fanctrlplus/scripts/array_monitor.sh"
 if [ -x "$script" ]; then
   nohup "$script" >/dev/null 2>&1 &
 fi
+]]>
 
 echo ""
 echo "------------------------------------------------"
 echo " Plugin &name; is installed."
 echo " Array monitor is running."
-echo " Author: ck9393"
-echo " Version: 1.2.0;"
+echo " Author: &author;"
+echo " Version: &version;"
 echo "------------------------------------------------"
 echo ""
 exit 0
-]]>
 </INLINE>
   </FILE>
 

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -4,11 +4,11 @@
   <!ENTITY version "1.2.0">
   <!ENTITY author "ck9393">
   <!ENTITY launch "Settings/fanctrlplus">
-  <!ENTITY txz "/boot/config/plugins/&name;/fanctrlplus-1.2.0.txz">
-  <!ENTITY url "https://github.com/ck9393/fanctrlplus/releases/download/v1.2.0/fanctrlplus-1.2.0.txz">
+  <!ENTITY txz "/boot/config/plugins/&name;/fanctrlplus-&version.txz">
+  <!ENTITY pluginURL "https://github.com/ck9393/fanctrlplus/releases/download/v&version/fanctrlplus-&version.txz">
 ]>
 
-<PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" min="6.9.0">
+<PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.9.0">
   <CATEGORY>System</CATEGORY>
   <PLUGINURL>https://github.com/ck9393/fanctrlplus</PLUGINURL>
 
@@ -30,7 +30,7 @@ rm -f /boot/config/plugins/fanctrlplus/fanctrlplus-*.txz
 
   <!-- 下载并安装新的 .txz -->
   <FILE Name="&txz;" Run="upgradepkg --install-new --reinstall">
-    <URL>&url;</URL>
+    <URL>&pluginURL;</URL>
   </FILE>
 
   <!-- 启动 array monitor 守护脚本 -->
@@ -45,10 +45,10 @@ fi
 
 echo ""
 echo "-----------------------------------------------------------"
-echo " Plugin fanctrlplus is installed."
+echo " Plugin &name is installed."
 echo " Array monitor is running."
-echo " Author: ck9393"
-echo " Version: 1.2.0"
+echo " Author: &author"
+echo " Version: &version"
 echo "-----------------------------------------------------------"
 echo ""
 exit 0
@@ -76,7 +76,7 @@ exit 0
   </FILE>
 
   <CHANGES>
-Release Notes – v1.2.0
+Release Notes – ###&verion
 
 
   </CHANGES>

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -9,6 +9,8 @@
 ]>
 
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" min="6.9.0">
+  <CATEGORY>System</CATEGORY>
+  <PLUGINURL>https://github.com/ck9393/fanctrlplus</PLUGINURL>
 
   <DESCRIPTION>
 FanCtrl Plus: Automatically control fan speed based on HDD, NVMe, and unassigned device temperatures.

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -48,8 +48,9 @@ echo ""
 echo "------------------------------------------------"
 echo " Plugin &name; is installed."
 echo " Array monitor is running."
-echo " Author: &author;"
-echo " Version: &version;"
+echo " Author: ck9393"
+echo " Version: 1.2.0;"
+echo "------------------------------------------------"
 echo ""
 exit 0
 ]]>

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -35,7 +35,8 @@ rm -f /boot/config/plugins/fanctrlplus/fanctrlplus-*.txz
 
   <!-- 启动 array monitor 守护脚本 -->
   <FILE Run="/bin/bash">
-    <INLINE>
+<INLINE>
+<![CDATA[
 #!/bin/bash
 # 启动 fanctrlplus 守护脚本
 script="/usr/local/emhttp/plugins/fanctrlplus/scripts/array_monitor.sh"
@@ -44,15 +45,15 @@ if [ -x "$script" ]; then
 fi
 
 echo ""
-echo "-----------------------------------------------------------"
+echo "------------------------------------------------"
 echo " Plugin &name; is installed."
 echo " Array monitor is running."
 echo " Author: &author;"
 echo " Version: &version;"
-echo "-----------------------------------------------------------"
 echo ""
 exit 0
-    </INLINE>
+]]>
+</INLINE>
   </FILE>
 
   <!-- 卸载时清理后台和文件 -->

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -4,8 +4,8 @@
   <!ENTITY version "1.2.0">
   <!ENTITY author "ck9393">
   <!ENTITY launch "Settings/fanctrlplus">
-  <!ENTITY txz "/boot/config/plugins/&name;/fanctrlplus-&version.txz">
-  <!ENTITY pluginURL "https://github.com/ck9393/fanctrlplus/releases/download/v&version/fanctrlplus-&version.txz">
+  <!ENTITY txz "/boot/config/plugins/&name;/fanctrlplus-&version;.txz">
+  <!ENTITY pluginURL "https://github.com/ck9393/fanctrlplus/releases/download/v&version;/fanctrlplus-&version;.txz">
 ]>
 
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.9.0">

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -38,7 +38,7 @@ rm -f /boot/config/plugins/fanctrlplus/fanctrlplus-*.txz
     <INLINE>
 #!/bin/bash
 go_file="/boot/config/go"
-startup_line="/usr/local/emhttp/plugins/fanctrlplus/scripts/rc.autofan start &"
+startup_line="/usr/local/emhttp/plugins/fanctrlplus/scripts/rc.autofan start &amp;
 
 # 如果 go 文件中不存在这一行，就添加
 grep -qF "$startup_line" "$go_file" || echo "$startup_line" >> "$go_file"

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -5,7 +5,7 @@
   <!ENTITY author "ck9393">
   <!ENTITY launch "Settings/fanctrlplus">
   <!ENTITY txz "/boot/config/plugins/&name;/fanctrlplus-&version;.txz">
-  <!ENTITY pluginURL "https://github.com/ck9393/fanctrlplus/releases/download/v1.2.0/fanctrlplus-1.2.0.txz">
+  <!ENTITY pluginURL "https://github.com/ck9393/fanctrlplus/releases/download/v&version;/fanctrlplus-&version;.txz">
 ]>
 
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.9.0">

--- a/fanctrlplus.plg
+++ b/fanctrlplus.plg
@@ -13,14 +13,14 @@
   <PLUGINURL>https://github.com/ck9393/fanctrlplus</PLUGINURL>
 
   <DESCRIPTION>
-FanCtrl Plus: Automatically control fan speed based on HDD, NVMe, and unassigned device temperatures.
+FanCtrl Plus: Automatically control fan speed based on disk temperature. This version includes full auto-start support for all array scenarios.
   </DESCRIPTION>
 
   <ICON>
 /usr/local/emhttp/plugins/fanctrlplus/images/fanctrlplus.png
   </ICON>
 
-  <!-- 清理旧版本的 txz（避免版本号相同但内容不同的缓存） -->
+  <!-- 清理旧 txz -->
   <FILE Run="/bin/bash">
     <INLINE>
 #!/bin/bash
@@ -33,20 +33,20 @@ rm -f /boot/config/plugins/fanctrlplus/fanctrlplus-*.txz
     <URL>&url;</URL>
   </FILE>
 
-  <!-- 开机自启：写入 /boot/config/go -->
+  <!-- 启动 array monitor 守护脚本 -->
   <FILE Run="/bin/bash">
     <INLINE>
 #!/bin/bash
-go_file="/boot/config/go"
-startup_line="/usr/local/emhttp/plugins/fanctrlplus/scripts/rc.autofan start &amp;"
-
-# 如果 go 文件中不存在这一行，就添加
-grep -qF "$startup_line" "$go_file" || echo "$startup_line" >> "$go_file"
+# 启动 fanctrlplus 守护脚本
+script="/usr/local/emhttp/plugins/fanctrlplus/scripts/array_monitor.sh"
+if [ -x "$script" ]; then
+  nohup "$script" >/dev/null 2>&1 &
+fi
 
 echo ""
 echo "-----------------------------------------------------------"
 echo " Plugin fanctrlplus is installed."
-echo " Auto-start entry added to /boot/config/go"
+echo " Array monitor is running."
 echo " Author: ck9393"
 echo " Version: 1.2.0"
 echo "-----------------------------------------------------------"
@@ -55,19 +55,22 @@ exit 0
     </INLINE>
   </FILE>
 
-  <!-- 卸载逻辑 -->
+  <!-- 卸载时清理后台和文件 -->
   <FILE Run="/bin/bash" Method="remove">
     <INLINE>
 #!/bin/bash
-/usr/local/emhttp/plugins/fanctrlplus/scripts/rc.autofan stop 2>/dev/null
+/usr/local/emhttp/plugins/fanctrlplus/scripts/rc.fanctrlplus stop 2>/dev/null
+pkill -f array_monitor.sh
+
 removepkg fanctrlplus
 rm -rf /usr/local/emhttp/plugins/fanctrlplus
 rm -rf /boot/config/plugins/fanctrlplus
 
-# 清除 go 文件中的自启动行
-sed -i '\|fanctrlplus/scripts/rc.autofan start|d' /boot/config/go
+# 清除 go 中旧自启行
+sed -i '\|rc.fanctrlplus start|d' /boot/config/go
+sed -i '\|array_monitor.sh|d' /boot/config/go
 
-echo "[fanctrlplus] Plugin removed and go entry cleaned."
+echo "[fanctrlplus] Plugin fully removed."
 exit 0
     </INLINE>
   </FILE>
@@ -75,26 +78,6 @@ exit 0
   <CHANGES>
 Release Notes – v1.2.0
 
-1. Improved disk selection UI
-	•	The Include Disks dropdown now shows full device labels:
-	•	Array devices (Parity, Disk 1~N)
-	•	NVMe and SATA drives in each pool
-	•	Devices are grouped by Array and individual Pools
-	•	Labels follow Unraid’s Main tab format (e.g. “Disk 3 - ST4000VN008”)
 
-2. Dynamic disk list rendering
-	•	All disk options are rendered using JavaScript for better performance
-	•	Hover tooltips show full device paths and IDs
-	•	Unraid flash drive is excluded from selection
-	•	Uses /dev/disk/by-id to ensure stable device mapping
-
-3. Auto-start improvement
-	•	Plugin now auto-starts on boot via /boot/config/go entry
-	•	No longer uses temporary at-based delayed startup
-
-⸻
-
-This release focuses on better clarity and flexibility for fan-to-disk control.
   </CHANGES>
-
 </PLUGIN>

--- a/include/Common.php
+++ b/include/Common.php
@@ -99,11 +99,10 @@ function list_valid_disks_by_id() {
   if (isset($groups['Array'])) {
     usort($groups['Array'], function($a, $b) {
       $order = function($label) {
-        if (str_starts_with($label, 'Parity')) {
-          return $label === 'Parity' ? 0 : 1; // Parity → 0, Parity 2 → 1
-        }
+        if (str_starts_with($label, 'Parity 2')) return 1;
+        if (str_starts_with($label, 'Parity'))   return 0;
         if (preg_match('/Disk (\d+)/', $label, $m)) {
-          return 2 + intval($m[1]); // Disk 1 → 3, Disk 2 → 4, ...
+          return 2 + intval($m[1]);
         }
         return 999;
       };

--- a/include/Common.php
+++ b/include/Common.php
@@ -98,16 +98,22 @@ function list_valid_disks_by_id() {
   // Array 内部排序（Parity → Parity 2 → Disk X）
   if (isset($groups['Array'])) {
     usort($groups['Array'], function($a, $b) {
-      $order = function($label) {
-        if (str_starts_with($label, 'Parity 2')) return -2;
-        if (str_starts_with($label, 'Parity'))   return -1;
-        if (preg_match('/Disk (\d+)/', $label, $m)) return intval($m[1]);
-        return 999;
-      };
-      return $order($a['label']) <=> $order($b['label']);
+      $la = $a['label'];
+      $lb = $b['label'];
+  
+      // ✅ 优先 Parity → Parity 2 → Disk X
+      if (str_starts_with($la, 'Parity') && !str_starts_with($lb, 'Parity')) return -1;
+      if (!str_starts_with($la, 'Parity') && str_starts_with($lb, 'Parity')) return 1;
+      if ($la === 'Parity') return -1;
+      if ($lb === 'Parity') return 1;
+  
+      // 排序 Disk N
+      preg_match('/Disk (\d+)/', $la, $ma);
+      preg_match('/Disk (\d+)/', $lb, $mb);
+      return ($ma[1] ?? 99) <=> ($mb[1] ?? 99);
     });
   }
-
+  
   // 其他组按 label 排序
   foreach ($groups as $group => &$entries) {
     if ($group !== 'Array') {

--- a/include/Common.php
+++ b/include/Common.php
@@ -98,19 +98,16 @@ function list_valid_disks_by_id() {
   // Array 内部排序（Parity → Parity 2 → Disk X）
   if (isset($groups['Array'])) {
     usort($groups['Array'], function($a, $b) {
-      $la = $a['label'];
-      $lb = $b['label'];
-  
-      // ✅ 优先 Parity → Parity 2 → Disk X
-      if (str_starts_with($la, 'Parity') && !str_starts_with($lb, 'Parity')) return -1;
-      if (!str_starts_with($la, 'Parity') && str_starts_with($lb, 'Parity')) return 1;
-      if ($la === 'Parity') return -1;
-      if ($lb === 'Parity') return 1;
-  
-      // 排序 Disk N
-      preg_match('/Disk (\d+)/', $la, $ma);
-      preg_match('/Disk (\d+)/', $lb, $mb);
-      return ($ma[1] ?? 99) <=> ($mb[1] ?? 99);
+      $order = function($label) {
+        if (str_starts_with($label, 'Parity')) {
+          return $label === 'Parity' ? 0 : 1; // Parity → 0, Parity 2 → 1
+        }
+        if (preg_match('/Disk (\d+)/', $label, $m)) {
+          return 2 + intval($m[1]); // Disk 1 → 3, Disk 2 → 4, ...
+        }
+        return 999;
+      };
+      return $order($a['label']) <=> $order($b['label']);
     });
   }
   

--- a/include/FanctrlLogic.php
+++ b/include/FanctrlLogic.php
@@ -97,27 +97,26 @@ switch ($op) {
       exec("$autofan start >/dev/null");
     }
     exit;
-
   case 'pause':
     $pwm = $_GET['pwm'] ?? '';
     if (is_file($pwm)) {
       $original_pwm  = trim(@file_get_contents($pwm));
       $pwm_enable    = $pwm . "_enable";
       $original_mode = is_file($pwm_enable) ? trim(@file_get_contents($pwm_enable)) : '2';
-
+  
       @file_put_contents($pwm_enable, "1");
       @file_put_contents($pwm, "0");
-
+  
       $restore_cmd = "sleep 30 && echo " . escapeshellarg($original_mode) . " > " . escapeshellarg($pwm_enable) .
                      " && echo " . escapeshellarg($original_pwm) . " > " . escapeshellarg($pwm);
       exec("nohup bash -c \"$restore_cmd\" >/dev/null 2>&1 &");
-
-      echo "Fan paused for 30 seconds";
+  
+      json_response(['status' => 'ok', 'message' => 'Fan paused for 30 seconds']);
     } else {
-      echo "Invalid PWM path";
+      json_response(['status' => 'error', 'message' => 'Invalid PWM path']);
     }
-    exit;
-
+    break;
+  
   case 'newtemp':
     $index = $_REQUEST['index'] ?? 0;
     $cfg_dir = "/boot/config/plugins/$plugin";

--- a/scripts/array_monitor.sh
+++ b/scripts/array_monitor.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# FanCtrlPlus Array Monitor
+LOG="/var/log/fanctrlplus_array_watch.log"
+CHECK_INTERVAL=5
+prev_state="unknown"
+
+while true; do
+  # 读取 array 启动状态
+  state=$(grep -Po '^arrayStarted="\K[^"]+' /var/local/emhttp/var.ini 2>/dev/null)
+
+  if [[ "$state" == "yes" && "$prev_state" != "yes" ]]; then
+    echo "[fanctrlplus] Detected array started at $(date)" >> "$LOG"
+    /usr/local/emhttp/plugins/fanctrlplus/scripts/rc.fanctrlplus start
+  fi
+
+  prev_state="$state"
+  sleep $CHECK_INTERVAL
+done


### PR DESCRIPTION
fanctrlplus v1.2.1 introduces small but useful improvements. The "Pause 30s" button now shows a proper countdown and restores automatically after 30 seconds, improving user feedback. Additionally, disks in the dropdown list are now sorted more intuitively, with "Parity" and "Parity 2" correctly shown before "Disk 1", "Disk 2", etc.

This version mainly improves UI clarity and minor fan control behavior.