### PR TITLE
Add auxiliary temperature sensor support (hwmon, storcli, nvidia-smi)…

### DIFF
--- a/fanctrlplus.page
+++ b/fanctrlplus.page
@@ -134,6 +134,7 @@ $pwms = list_pwm();
 $disks = list_valid_disks_by_id();
 $width = 300;
 $cpu_sensors = detect_cpu_sensors();
+$aux_sensors = detect_aux_sensors();
 
 // === 读取 FCP Airflow 开关 ===
 function fcp_airflow_enabled(string $cfg_dir): bool {
@@ -215,6 +216,23 @@ const dropdownChecklistOptions = {
       options.closest('td').find('.ui-dropdownchecklist-text').attr('title', tooltip);
     }, 10);
     return count === 0 ? '(None)' : `Selected ${count} Disk${count > 1 ? 's' : ''}`;
+  }
+};
+
+const auxDropdownChecklistOptions = {
+  emptyText: '(None)',
+  width: 300,
+  explicitClose: '...close',
+  textFormatFunction: function (options) {
+    const selected = options.filter(':selected');
+    const count = selected.length;
+    const tooltip = selected.map(function () {
+      return $(this).text();
+    }).get().join('\n') || '(None)';
+    setTimeout(() => {
+      options.closest('td').find('.ui-dropdownchecklist-text').attr('title', tooltip);
+    }, 10);
+    return count === 0 ? '(None)' : `Selected ${count} Sensor${count > 1 ? 's' : ''}`;
   }
 };
 
@@ -327,12 +345,14 @@ $(function() {
         if (hub)   hub.setAttribute('fill', hubColor);
 
         const cpuEnabled = block.find('select[name^="cpu_enable["]').val() === "1";
+        const auxEnabled = block.find('select[name^="aux_enable["]').val() === "1";
         const hasDisks = block.find('select[name^="disks["] option:selected').length > 0;
         const container = fanSvg.closest('.fan-svg-container');
         if (container) {
           const sources = [];
           if (cpuEnabled) sources.push("CPU");
           if (hasDisks) sources.push("Disk");
+          if (auxEnabled) sources.push("Aux");
 
           const sourceText = sources.length
             ? ` (based on ${sources.join(" and ")} temperature)`
@@ -440,6 +460,7 @@ $(function() {
       initOriginalForBlock($html);
 
       $html.find('.disk-select').dropdownchecklist(dropdownChecklistOptions);
+      $html.find('.aux-select').dropdownchecklist(auxDropdownChecklistOptions);
 
       updateAllFanStatus();
       ensureColumnDroppable();
@@ -458,12 +479,18 @@ $(function() {
           { selector: 'input[id^="high_temp_input_"]', unit: '°C', min: 1, max: 100 },
           { selector: 'input[id^="cpu_low_temp_input_"]', unit: '°C', min: 1, max: 95 },
           { selector: 'input[id^="cpu_high_temp_input_"]', unit: '°C', min: 1, max: 110 },
+          { selector: 'input[id^="aux_low_temp_input_"]', unit: '°C', min: 1, max: 110 },
+          { selector: 'input[id^="aux_high_temp_input_"]', unit: '°C', min: 1, max: 110 },
           { selector: 'input[id^="interval_input_"]', unit: ' min', min: 1, max: 60 }
         ]);
 
         $html.find('select[id^="cpu-enable-"]').each(function () {
           const index = this.id.replace('cpu-enable-', '');
           window.handleCpuEnableChange(this, index);
+        });
+        $html.find('select[id^="aux-enable-"]').each(function () {
+          const index = this.id.replace('aux-enable-', '');
+          window.handleAuxEnableChange(this, index);
         });
 
         bindFanSpeedEvents();
@@ -609,6 +636,8 @@ $(function() {
       { selector: 'input[id^="high_temp_input_"]', unit: '°C', min: 1, max: 100 },
       { selector: 'input[id^="cpu_low_temp_input_"]', unit: '°C', min: 1, max: 95 },
       { selector: 'input[id^="cpu_high_temp_input_"]', unit: '°C', min: 1, max: 110 },
+      { selector: 'input[id^="aux_low_temp_input_"]', unit: '°C', min: 1, max: 110 },
+      { selector: 'input[id^="aux_high_temp_input_"]', unit: '°C', min: 1, max: 110 },
       { selector: 'input[id^="interval_input_"]', unit: ' min', min: 1, max: 60 }
     ]);
     loadPWMOptions();
@@ -871,7 +900,11 @@ $(function() {
       cpu_enable: $block.find('select[name^="cpu_enable["]').val(),
       cpu_sensor: $block.find('select[name^="cpu_sensor["]').val(),
       cpu_min_temp: stripUnit($block.find('input[name^="cpu_min_temp["]').val()),
-      cpu_max_temp: stripUnit($block.find('input[name^="cpu_max_temp["]').val())
+      cpu_max_temp: stripUnit($block.find('input[name^="cpu_max_temp["]').val()),
+      aux_enable: $block.find('select[name^="aux_enable["]').val(),
+      aux_sensor: $block.find('select[name^="aux_sensor["]').val(),
+      aux_min_temp: stripUnit($block.find('input[name^="aux_min_temp["]').val()),
+      aux_max_temp: stripUnit($block.find('input[name^="aux_max_temp["]').val())
     };
     $block.data('original', original);
   }
@@ -896,7 +929,11 @@ $(function() {
         cpu_enable: $block.find('select[name^="cpu_enable["]').val(),
         cpu_sensor: $block.find('select[name^="cpu_sensor["]').val(),
         cpu_min_temp: stripUnit($block.find('input[name^="cpu_min_temp["]').val()),
-        cpu_max_temp: stripUnit($block.find('input[name^="cpu_max_temp["]').val())
+        cpu_max_temp: stripUnit($block.find('input[name^="cpu_max_temp["]').val()),
+        aux_enable: $block.find('select[name^="aux_enable["]').val(),
+        aux_sensor: $block.find('select[name^="aux_sensor["]').val(),
+        aux_min_temp: stripUnit($block.find('input[name^="aux_min_temp["]').val()),
+        aux_max_temp: stripUnit($block.find('input[name^="aux_max_temp["]').val())
       };
 
       if (JSON.stringify(original) !== JSON.stringify(current)) {
@@ -978,6 +1015,7 @@ $(function() {
   });
 
   $('.disk-select').dropdownchecklist(dropdownChecklistOptions);
+  $('.aux-select').dropdownchecklist(auxDropdownChecklistOptions);
 
   $('.fan-block').each(function () {
     initOriginalForBlock($(this));
@@ -1061,6 +1099,8 @@ $(function() {
       const idlePct = parseInt(stripUnit(block.find('input[name^="idle_percent["]').val()));
       const cpuLow = parseInt(stripUnit(block.find('input[name^="cpu_min_temp["]').val()));
       const cpuHigh = parseInt(stripUnit(block.find('input[name^="cpu_max_temp["]').val()));
+      const auxLow = parseInt(stripUnit(block.find('input[name^="aux_min_temp["]').val()));
+      const auxHigh = parseInt(stripUnit(block.find('input[name^="aux_max_temp["]').val()));
 
       if (!isNaN(lowTemp) && !isNaN(highTemp) && lowTemp >= highTemp) {
         alert(`Fan configuration "${name}": Disk Low Temp cannot exceed High Temp.`);
@@ -1070,6 +1110,12 @@ $(function() {
 
         if (!isNaN(cpuLow) && !isNaN(cpuHigh) && cpuLow >= cpuHigh) {
         alert(`Fan configuration "${name}": CPU Low Temp cannot exceed High Temp.`);
+        rangeValid = false;
+        return false;
+      }
+
+      if (!isNaN(auxLow) && !isNaN(auxHigh) && auxLow >= auxHigh) {
+        alert(`Fan configuration "${name}": Aux Low Temp cannot exceed High Temp.`);
         rangeValid = false;
         return false;
       }
@@ -1414,6 +1460,42 @@ $(function() {
     }
   };
 
+  window.handleAuxEnableChange = function(selectEl, index) {
+    const enabled = selectEl.value === "1";
+
+    const rows = document.querySelectorAll(`.aux-control-${index}`);
+    rows.forEach(row => {
+      row.querySelectorAll('.aux-input').forEach(el => {
+        el.disabled = !enabled;
+        el.classList.toggle('disabled', !enabled);
+      });
+    });
+
+    document.querySelectorAll(`.aux-control-${index} .aux-label`).forEach(label => {
+      label.classList.toggle('disabled', !enabled);
+    });
+
+    // Rebuild dropdownchecklist widget to reflect disabled state
+    const $block = $(selectEl).closest('.fan-block');
+    const $auxSelect = $block.find('.aux-select');
+    if ($auxSelect.length) {
+      $auxSelect.dropdownchecklist('destroy');
+      $auxSelect.dropdownchecklist(auxDropdownChecklistOptions);
+    }
+
+    if (enabled) {
+      const lowInput  = document.querySelector(`#aux_low_temp_input_${index}`);
+      const highInput = document.querySelector(`#aux_high_temp_input_${index}`);
+
+      if (lowInput && lowInput.value.trim() === '') {
+        lowInput.value = '40°C';
+      }
+      if (highInput && highInput.value.trim() === '') {
+        highInput.value = '70°C';
+      }
+    }
+  };
+
   // 初始化所有 block 的状态，并绑定 onchange
   window.addEventListener('load', function () {
     requestAnimationFrame(() => {
@@ -1425,6 +1507,14 @@ $(function() {
           window.handleCpuEnableChange(this, index);
         });
       });
+      document.querySelectorAll('select[id^="aux-enable-"]').forEach(select => {
+        const index = select.id.replace('aux-enable-', '');
+        window.handleAuxEnableChange(select, index);
+
+        select.addEventListener('change', function () {
+          window.handleAuxEnableChange(this, index);
+        });
+      });
     });
   });
   setTimeout(() => {
@@ -1432,6 +1522,13 @@ $(function() {
       const index = select.id.replace('cpu-enable-', '');
       const enabled = select.value === "1";
       document.querySelectorAll(`.cpu-control-${index} .cpu-label`).forEach(label => {
+        label.classList.toggle('disabled', !enabled);
+      });
+    });
+    document.querySelectorAll('select[id^="aux-enable-"]').forEach(select => {
+      const index = select.id.replace('aux-enable-', '');
+      const enabled = select.value === "1";
+      document.querySelectorAll(`.aux-control-${index} .aux-label`).forEach(label => {
         label.classList.toggle('disabled', !enabled);
       });
     });
@@ -1452,7 +1549,7 @@ $(function() {
           $cfg = parse_ini_file($path);
           $cfg['file'] = $file;
           $all_cfg[] = $cfg;
-          echo render_fan_block($cfg, $i++, $pwms, $disks, $pwm_labels, $cpu_sensors);
+          echo render_fan_block($cfg, $i++, $pwms, $disks, $pwm_labels, $cpu_sensors, $aux_sensors);
         }
       }
       ?>
@@ -1465,7 +1562,7 @@ $(function() {
           $cfg = parse_ini_file($path);
           $cfg['file'] = $file;
           $all_cfg[] = $cfg;
-          echo render_fan_block($cfg, $i++, $pwms, $disks, $pwm_labels, $cpu_sensors);
+          echo render_fan_block($cfg, $i++, $pwms, $disks, $pwm_labels, $cpu_sensors, $aux_sensors);
         }
       }
       ?>
@@ -1483,7 +1580,7 @@ $(function() {
       $cfg = parse_ini_file($path);
       $cfg['file'] = $basename;
       $all_cfg[] = $cfg;
-      $html = addslashes(render_fan_block($cfg, $i, $pwms, $disks, $pwm_labels, $cpu_sensors));
+      $html = addslashes(render_fan_block($cfg, $i, $pwms, $disks, $pwm_labels, $cpu_sensors, $aux_sensors));
       if ($count_left <= $count_right) {
         $target = '#fan-column-left';
         $count_left++;

--- a/include/Common.php
+++ b/include/Common.php
@@ -185,6 +185,122 @@ function list_pwm() {
   return $out;
 }
 
+// Find storcli binary (storcli64, storcli2, storcli) in common paths
+function find_storcli(): ?string {
+  $candidates = [
+    '/opt/MegaRAID/storcli/storcli64',
+    '/opt/MegaRAID/storcli/storcli',
+    '/usr/local/sbin/storcli64',
+    '/usr/local/sbin/storcli',
+    '/usr/local/bin/storcli64',
+    '/usr/local/bin/storcli',
+    '/usr/sbin/storcli64',
+    '/usr/sbin/storcli',
+    '/usr/bin/storcli64',
+    '/usr/bin/storcli',
+  ];
+  foreach ($candidates as $path) {
+    if (is_executable($path)) return $path;
+  }
+  // Fall back to PATH lookup
+  $which = trim(shell_exec("which storcli64 2>/dev/null") ?? '');
+  if ($which !== '' && is_executable($which)) return $which;
+  $which = trim(shell_exec("which storcli 2>/dev/null") ?? '');
+  if ($which !== '' && is_executable($which)) return $which;
+  return null;
+}
+
+// Detect LSI/MegaRAID controller temperatures via storcli
+// Returns array of ['path' => 'storcli:cX', 'label' => 'LSI RAID c0 - ROC (68°C)', 'chip' => ..., 'idx' => ...]
+function detect_storcli_temps(string $storcli_bin): array {
+  $result = [];
+
+  $output = shell_exec("$storcli_bin /call show temperature 2>/dev/null");
+  if (!$output) return $result;
+
+  $controller = 0;
+  $model = 'LSI RAID';
+
+  foreach (explode("\n", $output) as $line) {
+    $line = trim($line);
+
+    if (preg_match('/^Controller\s*=\s*(\d+)/i', $line, $m)) {
+      $controller = (int)$m[1];
+      continue;
+    }
+
+    // Product Name = SAS9341-8i
+    if (preg_match('/^Product Name\s*=\s*(.+)/i', $line, $m)) {
+      $model = trim($m[1]);
+      continue;
+    }
+
+    // ROC temperature(Degree Celsius) 68
+    if (preg_match('/ROC temperature.*\s(\d+)\s*$/i', $line, $m)) {
+      $temp = (int)$m[1];
+      if ($temp > 0) {
+        $result[] = [
+          'path'  => "storcli:c{$controller}:roc",
+          'label' => "{$model} c{$controller} - ROC ({$temp}°C)",
+          'chip'  => 'RAID Controller',
+          'idx'   => $controller * 10,
+        ];
+      }
+      continue;
+    }
+  }
+
+  return $result;
+}
+
+// Find nvidia-smi binary
+function find_nvidia_smi(): ?string {
+  $candidates = [
+    '/usr/bin/nvidia-smi',
+    '/usr/local/bin/nvidia-smi',
+    '/usr/lib/nvidia/bin/nvidia-smi',
+  ];
+  foreach ($candidates as $path) {
+    if (is_executable($path)) return $path;
+  }
+  $which = trim(shell_exec("which nvidia-smi 2>/dev/null") ?? '');
+  if ($which !== '' && is_executable($which)) return $which;
+  return null;
+}
+
+// Detect NVIDIA GPU temperatures via nvidia-smi
+// Returns array of ['path' => 'nvidia:gpu0', 'label' => 'NVIDIA GeForce RTX 3080 - GPU 0 (55°C)', ...]
+function detect_nvidia_temps(string $nvidia_smi): array {
+  $result = [];
+
+  // Query all GPUs: index, name, temperature
+  $output = shell_exec("$nvidia_smi --query-gpu=index,name,temperature.gpu --format=csv,noheader,nounits 2>/dev/null");
+  if (!$output) return $result;
+
+  foreach (explode("\n", trim($output)) as $line) {
+    $line = trim($line);
+    if ($line === '') continue;
+
+    $parts = array_map('trim', explode(',', $line));
+    if (count($parts) < 3) continue;
+
+    $idx  = (int)$parts[0];
+    $name = $parts[1];
+    $temp = (int)$parts[2];
+
+    if ($temp <= 0) continue;
+
+    $result[] = [
+      'path'  => "nvidia:gpu{$idx}",
+      'label' => "{$name} - GPU {$idx} ({$temp}°C)",
+      'chip'  => 'GPU',
+      'idx'   => $idx,
+    ];
+  }
+
+  return $result;
+}
+
 function list_valid_disks_by_id() {
   $seen = [];
   $groups = [];
@@ -306,6 +422,123 @@ function detect_cpu_sensors(): array {
     $final[$e['path']] = $e['label'];
   }
   return $final;
+}
+
+// Scan all hwmon sensors and return non-CPU, non-NVMe temperature sensors
+// (e.g. ethernet cards, chipset/PCH, VRM, GPU, board temps)
+function detect_aux_sensors(): array {
+  $result = [];
+
+  $cpu_chips_exact = ['k10temp','coretemp','zenpower'];
+  $superio_prefixes = ['it8','it86','it87','nct6','nct67','nct68','nuvoton'];
+  $nvme_deny = ['nvme'];
+
+  // CPU-related label keywords to exclude from SuperIO chips
+  $cpu_labels = ['Package id', 'Tctl', 'Tdie', 'CPU Temp', 'PECI Agent', 'CPUTIN', 'Core'];
+
+  foreach (glob('/sys/class/hwmon/hwmon*') as $hwmonPath) {
+    $nameFile = "$hwmonPath/name";
+    if (!is_readable($nameFile)) continue;
+    $chipName = trim(@file_get_contents($nameFile));
+    $chipLower = strtolower($chipName);
+
+    // Skip dedicated CPU chips entirely
+    if (in_array($chipLower, $cpu_chips_exact, true)) continue;
+
+    // Skip NVMe chips (handled by disk/smartctl)
+    foreach ($nvme_deny as $deny) {
+      if (strpos($chipLower, $deny) !== false) continue 2;
+    }
+
+    $isSuperIO = false;
+    foreach ($superio_prefixes as $p) {
+      if (strpos($chipLower, $p) === 0) { $isSuperIO = true; break; }
+    }
+
+    // Collect sensors with labels
+    foreach (glob("$hwmonPath/temp*_label") as $labelFile) {
+      $label = trim(@file_get_contents($labelFile));
+      $input = str_replace('_label', '_input', $labelFile);
+      if (!is_readable($input)) continue;
+
+      $raw = trim(@file_get_contents($input));
+      $c   = is_numeric($raw) ? intval($raw) / 1000 : null;
+      if ($c === null || $c <= 0) continue;
+
+      // For SuperIO chips, skip CPU-related labels (those belong to detect_cpu_sensors)
+      if ($isSuperIO) {
+        $isCpuLabel = false;
+        foreach ($cpu_labels as $cpuKey) {
+          if (stripos($label, $cpuKey) !== false) { $isCpuLabel = true; break; }
+        }
+        if ($isCpuLabel) continue;
+      }
+
+      $idxNum = 999;
+      if (preg_match('#/temp(\d+)_input$#', $input, $m)) $idxNum = (int)$m[1];
+
+      $tempC = round($c, 1) . '°C';
+      $result[] = [
+        'path'  => $input,
+        'label' => "$chipName - $label ($tempC)",
+        'chip'  => $chipName,
+        'idx'   => $idxNum,
+      ];
+    }
+
+    // For chips without labels, include raw temp*_input files
+    if (count(glob("$hwmonPath/temp*_label")) === 0) {
+      foreach (glob("$hwmonPath/temp*_input") as $input) {
+        if (!is_readable($input)) continue;
+        $raw = trim(@file_get_contents($input));
+        $c   = is_numeric($raw) ? intval($raw) / 1000 : null;
+        if ($c === null || $c <= 0) continue;
+
+        $idxNum = 999;
+        if (preg_match('#/temp(\d+)_input$#', $input, $m)) $idxNum = (int)$m[1];
+
+        $tempC = round($c, 1) . '°C';
+        $result[] = [
+          'path'  => $input,
+          'label' => "$chipName - temp" . $idxNum . " ($tempC)",
+          'chip'  => $chipName,
+          'idx'   => $idxNum,
+        ];
+      }
+    }
+  }
+
+  // Append LSI/MegaRAID controller temperatures via storcli (if available)
+  $storcli_bin = find_storcli();
+  if ($storcli_bin !== null) {
+    foreach (detect_storcli_temps($storcli_bin) as $st) {
+      $result[] = $st;
+    }
+  }
+
+  // Append NVIDIA GPU temperatures via nvidia-smi (if available)
+  $nvidia_smi = find_nvidia_smi();
+  if ($nvidia_smi !== null) {
+    foreach (detect_nvidia_temps($nvidia_smi) as $nv) {
+      $result[] = $nv;
+    }
+  }
+
+  // Sort by chip name, then sensor index
+  usort($result, function($a, $b){
+    return strnatcasecmp($a['chip'], $b['chip'])
+        ?: ($a['idx'] <=> $b['idx']);
+  });
+
+  // Group by chip name for optgroup display
+  $grouped = [];
+  foreach ($result as $e) {
+    $grouped[$e['chip']][] = [
+      'path'  => $e['path'],
+      'label' => $e['label'],
+    ];
+  }
+  return $grouped;
 }
 
   // 映射 /dev/nvmeXp1 → pool 名（通过 zpool list -v）

--- a/include/FanBlockRender.php
+++ b/include/FanBlockRender.php
@@ -9,7 +9,7 @@ if (is_file($label_file)) {
   }
 }
 
-function render_fan_block($cfg, $i, $pwms, $disks, $pwm_labels, $cpu_sensors) {
+function render_fan_block($cfg, $i, $pwms, $disks, $pwm_labels, $cpu_sensors, $aux_sensors = []) {
   // PWM fallback（如果值为空，则默认 fallback 为 40% 和 100%）
   $pwm_raw = isset($cfg['pwm']) && is_numeric($cfg['pwm']) ? $cfg['pwm'] : 102;
   $max_raw = isset($cfg['max']) && is_numeric($cfg['max']) ? $cfg['max'] : 255;
@@ -300,6 +300,66 @@ function render_fan_block($cfg, $i, $pwms, $disks, $pwm_labels, $cpu_sensors) {
                     title="High Temp: <?=intval($cfg['cpu_max_temp'] ?? 75)?>°C"
                     placeholder="High °C"
                     <?=($cfg['cpu_enable'] ?? '') != '1' ? 'disabled' : ''?>>
+            </div>
+          </td>
+        </tr>
+
+        <tr><td colspan="2" class="subhead">Auxiliary Sensor Settings</td></tr>
+
+        <!-- Aux Temp Monitoring Dropdown -->
+        <tr>
+          <td class="fcp-help-cursor" title="Enable or disable monitoring an auxiliary temperature sensor (e.g. network card, chipset, VRM) for this fan.">Aux Temp Monitor:</td>
+          <td>
+            <select id="aux-enable-<?=$i?>" name="aux_enable[<?=$i?>]" class="fcp-enable-select" onchange="handleAuxEnableChange(this, <?=$i?>);">
+              <option value="0" <?=($cfg['aux_enable'] ?? '') != '1' ? 'selected' : ''?>>Disabled</option>
+              <option value="1" <?=($cfg['aux_enable'] ?? '') == '1' ? 'selected' : ''?>>Enabled</option>
+            </select>
+          </td>
+        </tr>
+
+        <!-- Aux Sensor(s) -->
+        <tr class="aux-control aux-control-<?=$i?>">
+          <td class="aux-label fcp-help-cursor" title="Select one or more auxiliary temperature sensors to monitor. The highest temperature across all selected sensors is used. Lists non-CPU, non-NVMe hwmon sensors, plus storcli/nvidia-smi if available.">Include Sensor(s):</td>
+          <td>
+            <?php $aux_selected = array_filter(explode(',', $cfg['aux_sensor'] ?? '')); ?>
+            <select class="aux-select aux-input fcp-w-300" name="aux_sensor[<?=$i?>][]" multiple <?=($cfg['aux_enable'] ?? '') != '1' ? 'disabled' : ''?>>
+              <?php foreach ($aux_sensors as $group => $entries): ?>
+                <optgroup label="<?=htmlspecialchars($group)?>">
+                  <?php foreach ($entries as $sensor): ?>
+                    <option value="<?=htmlspecialchars($sensor['path'])?>" <?=in_array($sensor['path'], $aux_selected) ? 'selected' : ''?>><?=htmlspecialchars($sensor['label'])?></option>
+                  <?php endforeach; ?>
+                </optgroup>
+              <?php endforeach; ?>
+            </select>
+          </td>
+        </tr>
+
+        <!-- Aux Temp Range -->
+        <tr class="aux-control aux-control-<?=$i?>">
+          <td class="aux-label fcp-help-cursor" title="Fan runs at minimum speed at or below Low Temp, and maximum speed at or above High Temp. See chart for details.">Aux Temperature Range:</td>
+          <td>
+            <div class="fcp-range-grid">
+              <input type="text"
+                    id="aux_low_temp_input_<?=$i?>"
+                    name="aux_min_temp[<?=$i?>]"
+                    class="aux-input fcp-input-fullleft"
+                    inputmode="numeric"
+                    value="<?=htmlspecialchars(($cfg['aux_min_temp'] ?? '') . '°C')?>"
+                    title="Low Temp: <?=intval($cfg['aux_min_temp'] ?? 40)?>°C"
+                    placeholder="Low °C"
+                    <?=($cfg['aux_enable'] ?? '') != '1' ? 'disabled' : ''?>>
+
+              <span class="fcp-center">~</span>
+
+              <input type="text"
+                    id="aux_high_temp_input_<?=$i?>"
+                    name="aux_max_temp[<?=$i?>]"
+                    class="aux-input fcp-input-fullleft"
+                    inputmode="numeric"
+                    value="<?=htmlspecialchars(($cfg['aux_max_temp'] ?? '') . '°C')?>"
+                    title="High Temp: <?=intval($cfg['aux_max_temp'] ?? 70)?>°C"
+                    placeholder="High °C"
+                    <?=($cfg['aux_enable'] ?? '') != '1' ? 'disabled' : ''?>>
             </div>
           </td>
         </tr>

--- a/include/FanctrlLogic.php
+++ b/include/FanctrlLogic.php
@@ -152,6 +152,10 @@ switch ($op) {
     cpu_sensor=""
     cpu_min_temp=""
     cpu_max_temp=""
+    aux_enable="0"
+    aux_sensor=""
+    aux_min_temp=""
+    aux_max_temp=""
     INI
     );
 
@@ -164,9 +168,10 @@ switch ($op) {
     $pwms = list_pwm();
     $disks = list_valid_disks_by_id();
     $cpu_sensors = detect_cpu_sensors();
+    $aux_sensors = detect_aux_sensors();
 
     header('Content-Type: text/html; charset=utf-8');
-    echo render_fan_block($cfg, $page_index, $pwms, $disks, $pwm_labels, $cpu_sensors); 
+    echo render_fan_block($cfg, $page_index, $pwms, $disks, $pwm_labels, $cpu_sensors, $aux_sensors);
     exit;
 
   case 'setsyslog':

--- a/include/chart-handler.js
+++ b/include/chart-handler.js
@@ -15,7 +15,7 @@ async function fetchRealtimeData(custom) {
   const [tempPart, rpmStr = ''] = raw.split('|');
 
   // 1) 星号：磁盘休眠 / Idle
-  const starMatch = /^\*\s*\((CPU|Disk|Idle)\)/i.exec(tempPart);
+  const starMatch = /^\*\s*\((CPU|Disk|Aux|Idle)\)/i.exec(tempPart);
   if (starMatch) {
     const origin = starMatch[1]; // CPU / Disk / Idle
     const rpm = /^\d+$/.test(rpmStr) ? parseInt(rpmStr, 10) : null;
@@ -24,7 +24,7 @@ async function fetchRealtimeData(custom) {
   }
 
   // 2) 正常数字温度
-  const numMatch = /(\d+)\s*\((CPU|Disk)\)/i.exec(tempPart);
+  const numMatch = /(\d+)\s*\((CPU|Disk|Aux)\)/i.exec(tempPart);
   if (!numMatch) return { noCache: true };
 
   const temp   = parseInt(numMatch[1], 10);
@@ -61,8 +61,12 @@ window.showFanChart = function (btn) {
   const cpuEnabled = getSelectVal('[name^="cpu_enable["]') === '1';
   const cpuLow = getNum('[name^="cpu_min_temp["]');
   const cpuHigh = getNum('[name^="cpu_max_temp["]');
+  const auxEnabled = getSelectVal('[name^="aux_enable["]') === '1';
+  const auxLow = getNum('[name^="aux_min_temp["]');
+  const auxHigh = getNum('[name^="aux_max_temp["]');
   const hasDiskChart = diskSelected && pwmMin !== null && pwmMax !== null;
   const hasCpuChart = cpuEnabled && cpuLow !== null && cpuHigh !== null;
+  const hasAuxChart = auxEnabled && auxLow !== null && auxHigh !== null;
 
   if ([pwmMin, pwmMax, tempLow, tempHigh].some(v => v === null)) {
     Swal.fire('⚠️ Missing input', 'Please fill in all Disk Temp and PWM values.', 'warning');
@@ -121,18 +125,37 @@ window.showFanChart = function (btn) {
     });
   }
 
+  if (auxEnabled && auxLow !== null && auxHigh !== null) {
+    const auxPoints = makeLinePoints(auxLow, pwmMin, auxHigh, pwmMax);
+    const auxRadius = makePointRadiusArray(auxPoints.length);
+
+    datasets.push({
+    label: 'Aux Temp → PWM (%)',
+    data: auxPoints,
+    borderColor: '#0f9d58',
+    backgroundColor: 'rgba(15,157,88,0.1)',
+    borderWidth: 2,
+    pointRadius: auxRadius,
+    pointHoverRadius: 6,
+    fill: false,
+    tension: 0.4
+    });
+  }
+
   // 控制权注解说明文字
+  const activeSources = [];
+  if (diskSelected) activeSources.push('Disk');
+  if (cpuEnabled) activeSources.push('CPU');
+  if (auxEnabled) activeSources.push('Aux');
   let footerNote = '';
 
-  if (!cpuEnabled && !diskSelected) {
+  if (activeSources.length === 0) {
     footerNote = '⚠️ No rules defined — fan will not be controlled';
-    } else if (cpuEnabled && !diskSelected) {
-    footerNote = '💡 No disk selected — only CPU rule applies';
-    } else if (!cpuEnabled && diskSelected) {
-    footerNote = '💡 CPU control is disabled — only Disk rule applies';
-    } else {
-    footerNote = '💡 CPU and Disk rules are active — Fan PWM = max(Disk, CPU)';
-    }
+  } else if (activeSources.length === 1) {
+    footerNote = `💡 Only ${activeSources[0]} rule applies`;
+  } else {
+    footerNote = `💡 ${activeSources.join(' and ')} rules are active — Fan PWM = max(${activeSources.join(', ')})`;
+  }
     
   Swal.fire({
     title: `📈 ${name}`,
@@ -150,12 +173,14 @@ window.showFanChart = function (btn) {
     // 1) 只取一次的快照（避免 5s 刷新时 DOM 状态抖动）
     const customName = custom; // 供后端取 /var 的 key
     const snapCpuEnabled = getSelectVal('[name^="cpu_enable["]') === '1';
+    const snapAuxEnabled = getSelectVal('[name^="aux_enable["]') === '1';
     const disksElSnap = block.querySelector('[name^="disks["], [name^="include[]"]');
     const snapDiskSelected = !!(disksElSnap && disksElSnap.selectedOptions && disksElSnap.selectedOptions.length > 0);
 
     // 找到对应的 dataset（有可能没有）
     const dsCPU  = datasets.find(d => d.label && d.label.includes('CPU'));
     const dsDisk = datasets.find(d => d.label && d.label.includes('Disk'));
+    const dsAux  = datasets.find(d => d.label && d.label.includes('Aux'));
 
     // 顶部 Current 文本节点
     const liveNote = document.getElementById('fan-chart-live-note');
@@ -254,7 +279,7 @@ window.showFanChart = function (btn) {
               callbacks: {
                 title(items) { return `${items[0].parsed.x}°C`; },
                 label(ctx) {
-                  const label = ctx.dataset.label.includes('Disk') ? 'Disk Temp' : 'CPU Temp';
+                  const label = ctx.dataset.label.includes('Disk') ? 'Disk Temp' : ctx.dataset.label.includes('Aux') ? 'Aux Temp' : 'CPU Temp';
                   const percent = ctx.parsed.y;
                   const pwm = Math.round(percent * 2.55);
                   return `${label} → Fan Speed = ${percent.toFixed(0)}% (PWM ${pwm})`;
@@ -325,7 +350,7 @@ window.showFanChart = function (btn) {
           }
           vLine.style.display = hLine.style.display = dot.style.display = 'none';
         } else {
-          const ds = origin === 'CPU' ? dsCPU : dsDisk;
+          const ds = origin === 'CPU' ? dsCPU : origin === 'Aux' ? dsAux : dsDisk;
           percent = pickPercentNearest(ds, temp);
           if (percent != null) {
             const pwm = Math.round(percent * 2.55);
@@ -378,6 +403,8 @@ window.showFanChart = function (btn) {
           html += '<br><span style="color:#999;">(CPU was disabled, still active until Apply)</span>';
         } else if (origin === 'Disk' && !snapDiskSelected) {
           html += '<br><span style="color:#999;">(Disk was deselected, still active until Apply)</span>';
+        } else if (origin === 'Aux' && !snapAuxEnabled) {
+          html += '<br><span style="color:#999;">(Aux was disabled, still active until Apply)</span>';
         }
 
         liveNote.innerHTML = html;

--- a/include/update.fanctrlplus.php
+++ b/include/update.fanctrlplus.php
@@ -86,6 +86,21 @@ foreach ($_POST['#file'] as $i => $file) {
     $cpu_max_temp = '';
   }
 
+  // Aux sensor fallback
+  $aux_enable = $_POST['aux_enable'][$i] ?? '0';
+  $aux_sensor = isset($_POST['aux_sensor'][$i]) ? implode(',', $_POST['aux_sensor'][$i]) : '';
+
+  $aux_min_raw = $_POST['aux_min_temp'][$i] ?? '';
+  $aux_max_raw = $_POST['aux_max_temp'][$i] ?? '';
+
+  if ($aux_enable === '1') {
+    $aux_min_temp = is_numeric($amin = preg_replace('/[^0-9]/', '', $aux_min_raw)) ? intval($amin) : 40;
+    $aux_max_temp = is_numeric($amax = preg_replace('/[^0-9]/', '', $aux_max_raw)) ? intval($amax) : 70;
+  } else {
+    $aux_min_temp = '';
+    $aux_max_temp = '';
+  }
+
   // Custom Name 不能为空
   if ($custom === '') {
     ob_clean();
@@ -195,6 +210,10 @@ foreach ($_POST['#file'] as $i => $file) {
     'cpu_sensor'    => $cpu_sensor,
     'cpu_min_temp'  => $cpu_min_temp,
     'cpu_max_temp'  => $cpu_max_temp,
+    'aux_enable'    => $aux_enable,
+    'aux_sensor'    => $aux_sensor,
+    'aux_min_temp'  => $aux_min_temp,
+    'aux_max_temp'  => $aux_max_temp,
   ];
 
   $content = '';

--- a/scripts/fanctrlplus_loop.sh
+++ b/scripts/fanctrlplus_loop.sh
@@ -27,6 +27,26 @@ if (( idle_pwm_abs > min_pwm_abs )); then
   idle_pwm_abs="$min_pwm_abs"
 fi
 
+# Locate external tool binaries for aux sensor reading
+storcli_bin=""
+nvidia_smi_bin=""
+if [[ "${aux_sensor:-}" == *storcli:* ]]; then
+  for candidate in /opt/MegaRAID/storcli/storcli64 /opt/MegaRAID/storcli/storcli \
+                   /usr/local/sbin/storcli64 /usr/local/sbin/storcli \
+                   /usr/local/bin/storcli64 /usr/local/bin/storcli \
+                   /usr/sbin/storcli64 /usr/sbin/storcli \
+                   /usr/bin/storcli64 /usr/bin/storcli; do
+    if [[ -x "$candidate" ]]; then storcli_bin="$candidate"; break; fi
+  done
+  [[ -z "$storcli_bin" ]] && storcli_bin=$(command -v storcli64 2>/dev/null || command -v storcli 2>/dev/null || true)
+fi
+if [[ "${aux_sensor:-}" == *nvidia:* ]]; then
+  for candidate in /usr/bin/nvidia-smi /usr/local/bin/nvidia-smi /usr/lib/nvidia/bin/nvidia-smi; do
+    if [[ -x "$candidate" ]]; then nvidia_smi_bin="$candidate"; break; fi
+  done
+  [[ -z "$nvidia_smi_bin" ]] && nvidia_smi_bin=$(command -v nvidia-smi 2>/dev/null || true)
+fi
+
 plugin="fanctrlplus"
 custom="${custom:-$(basename "$cfg_file" .cfg)}"
 controller_enable="${controller}_enable"
@@ -60,6 +80,55 @@ while true; do
     fi
   else
     cpu_temp="-"
+  fi
+
+  # === Aux Sensor Temperature (iterate CSV, take max) ===
+  aux_pwm_val=0
+  aux_temp="-"
+  if [[ "${aux_enable:-0}" == "1" && -n "$aux_sensor" ]]; then
+    aux_max_valid=0
+
+    IFS=',' read -ra aux_list <<< "$aux_sensor"
+    for sensor in "${aux_list[@]}"; do
+      cur_temp=0
+
+      if [[ "$sensor" == storcli:* ]]; then
+        if [[ -n "$storcli_bin" && "$sensor" =~ ^storcli:c([0-9]+):roc$ ]]; then
+          sc_ctrl="${BASH_REMATCH[1]}"
+          cur_temp=$("$storcli_bin" "/c${sc_ctrl}" show temperature 2>/dev/null \
+            | awk '/ROC temperature/{print $NF; exit}')
+          cur_temp=${cur_temp:-0}
+        fi
+      elif [[ "$sensor" == nvidia:* ]]; then
+        if [[ -n "$nvidia_smi_bin" && "$sensor" =~ ^nvidia:gpu([0-9]+)$ ]]; then
+          gpu_idx="${BASH_REMATCH[1]}"
+          cur_temp=$("$nvidia_smi_bin" --query-gpu=temperature.gpu --format=csv,noheader,nounits -i "$gpu_idx" 2>/dev/null)
+          cur_temp=${cur_temp:-0}
+        fi
+      elif [[ -f "$sensor" ]]; then
+        raw=$(cat "$sensor")
+        [[ "$raw" =~ ^[0-9]+$ ]] && cur_temp=$((raw / 1000))
+        cur_temp=${cur_temp:-0}
+      fi
+
+      if [[ "$cur_temp" =~ ^[0-9]+$ ]] && (( cur_temp > aux_max_valid )); then
+        aux_max_valid=$cur_temp
+      fi
+    done
+
+    if (( aux_max_valid > 0 )); then
+      aux_temp=$aux_max_valid
+
+      if (( aux_temp <= aux_min_temp )); then
+        aux_pwm_val=$pwm
+      elif (( aux_temp >= aux_max_temp )); then
+        aux_pwm_val=$max
+      else
+        delta=$((aux_temp - aux_min_temp))
+        range=$((aux_max_temp - aux_min_temp))
+        aux_pwm_val=$((pwm + delta * (max - pwm) / range))
+      fi
+    fi
   fi
 
   # === Disk 温控 PWM ===
@@ -124,6 +193,12 @@ while true; do
     pwm_val=$disk_pwm_val
     max_temp=$disk_max
     temp_origin=$([ -n "$disks" ] && echo "(Disk)" || echo "(CPU)")
+  fi
+
+  if (( aux_pwm_val > pwm_val )); then
+    pwm_val=$aux_pwm_val
+    max_temp=$aux_temp
+    temp_origin="(Aux)"
   fi
 
   # 避免空写入

--- a/scripts/fanctrlplus_refresh_single.sh
+++ b/scripts/fanctrlplus_refresh_single.sh
@@ -9,6 +9,26 @@ source "$cfg_file"
 max="${max:-255}"
 controller_enable="${controller}_enable"
 
+# Locate external tool binaries for aux sensor reading
+storcli_bin=""
+nvidia_smi_bin=""
+if [[ "${aux_sensor:-}" == *storcli:* ]]; then
+  for candidate in /opt/MegaRAID/storcli/storcli64 /opt/MegaRAID/storcli/storcli \
+                   /usr/local/sbin/storcli64 /usr/local/sbin/storcli \
+                   /usr/local/bin/storcli64 /usr/local/bin/storcli \
+                   /usr/sbin/storcli64 /usr/sbin/storcli \
+                   /usr/bin/storcli64 /usr/bin/storcli; do
+    if [[ -x "$candidate" ]]; then storcli_bin="$candidate"; break; fi
+  done
+  [[ -z "$storcli_bin" ]] && storcli_bin=$(command -v storcli64 2>/dev/null || command -v storcli 2>/dev/null || true)
+fi
+if [[ "${aux_sensor:-}" == *nvidia:* ]]; then
+  for candidate in /usr/bin/nvidia-smi /usr/local/bin/nvidia-smi /usr/lib/nvidia/bin/nvidia-smi; do
+    if [[ -x "$candidate" ]]; then nvidia_smi_bin="$candidate"; break; fi
+  done
+  [[ -z "$nvidia_smi_bin" ]] && nvidia_smi_bin=$(command -v nvidia-smi 2>/dev/null || true)
+fi
+
 # === CPU 温度 ===
 cpu_pwm_val=0
 if [[ "${cpu_enable:-0}" == "1" && -n "$cpu_sensor" && -f "$cpu_sensor" ]]; then
@@ -29,6 +49,54 @@ else
   cpu_temp="-"
 fi
 
+# === Aux Sensor Temperature (iterate CSV, take max) ===
+aux_pwm_val=0
+aux_temp="-"
+if [[ "${aux_enable:-0}" == "1" && -n "$aux_sensor" ]]; then
+  aux_max_valid=0
+
+  IFS=',' read -ra aux_list <<< "$aux_sensor"
+  for sensor in "${aux_list[@]}"; do
+    cur_temp=0
+
+    if [[ "$sensor" == storcli:* ]]; then
+      if [[ -n "$storcli_bin" && "$sensor" =~ ^storcli:c([0-9]+):roc$ ]]; then
+        sc_ctrl="${BASH_REMATCH[1]}"
+        cur_temp=$("$storcli_bin" "/c${sc_ctrl}" show temperature 2>/dev/null \
+          | awk '/ROC temperature/{print $NF; exit}')
+        cur_temp=${cur_temp:-0}
+      fi
+    elif [[ "$sensor" == nvidia:* ]]; then
+      if [[ -n "$nvidia_smi_bin" && "$sensor" =~ ^nvidia:gpu([0-9]+)$ ]]; then
+        gpu_idx="${BASH_REMATCH[1]}"
+        cur_temp=$("$nvidia_smi_bin" --query-gpu=temperature.gpu --format=csv,noheader,nounits -i "$gpu_idx" 2>/dev/null)
+        cur_temp=${cur_temp:-0}
+      fi
+    elif [[ -f "$sensor" ]]; then
+      raw=$(cat "$sensor")
+      [[ "$raw" =~ ^[0-9]+$ ]] && cur_temp=$((raw / 1000))
+      cur_temp=${cur_temp:-0}
+    fi
+
+    if [[ "$cur_temp" =~ ^[0-9]+$ ]] && (( cur_temp > aux_max_valid )); then
+      aux_max_valid=$cur_temp
+    fi
+  done
+
+  if (( aux_max_valid > 0 )); then
+    aux_temp=$aux_max_valid
+
+    if (( aux_temp <= aux_min_temp )); then
+      aux_pwm_val=$pwm
+    elif (( aux_temp >= aux_max_temp )); then
+      aux_pwm_val=$max
+    else
+      delta=$((aux_temp - aux_min_temp))
+      range=$((aux_max_temp - aux_min_temp))
+      aux_pwm_val=$((pwm + delta * (max - pwm) / range))
+    fi
+  fi
+fi
 
 # === Disk 温控 PWM ===
 disk_pwm_val=0
@@ -92,6 +160,12 @@ else
   pwm_val=$disk_pwm_val
   max_temp=$disk_max
   temp_origin=$([ -n "$disks" ] && echo "(Disk)" || echo "(CPU)")
+fi
+
+if (( aux_pwm_val > pwm_val )); then
+  pwm_val=$aux_pwm_val
+  max_temp=$aux_temp
+  temp_origin="(Aux)"
 fi
 
 # 避免空写入


### PR DESCRIPTION
Add a third temperature source type ("Aux") alongside existing Disk and CPU monitoring. This allows fans to be controlled based on any system temperature sensor — ethernet cards, chipset/PCH, VRM, LSI RAID controllers, NVIDIA GPUs, or any other hwmon sensor not covered by CPU/disk detection.

Key changes:
- New detect_aux_sensors() discovers non-CPU, non-NVMe hwmon sensors, plus LSI controller temps via storcli and NVIDIA GPU temps via nvidia-smi
- UI: "Auxiliary Sensor Settings" with multi-select checklist dropdown (matching the Include Disks pattern) and temperature range inputs
- Daemon: iterates all selected aux sensors, uses highest temp for PWM
- Supports three sensor backends: sysfs hwmon, storcli, nvidia-smi
- Final PWM = max(disk_pwm, cpu_pwm, aux_pwm)
- Chart: green aux dataset line with full live crosshair support
- Fully backward compatible — existing configs without aux fields work unchanged

<img width="950" height="599" alt="Screenshot 2026-03-28 at 20 56 38" src="https://github.com/user-attachments/assets/c720aa98-e649-4b6c-b311-d7bf9f15238c" />
<img width="948" height="590" alt="Screenshot 2026-03-28 at 21 00 23" src="https://github.com/user-attachments/assets/67e0671c-5ccc-4614-869e-5c2e1dbaacff" />
